### PR TITLE
fix: exclude node_modules in Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "jest": {
     "modulePathIgnorePatterns": [
       "<rootDir>/src/",
-      "<rootDir>/legacy/"
+      "<rootDir>/legacy/",
+      "/node_modules/"
     ]
   },
   "scripts": {


### PR DESCRIPTION
- Add `node_modules` to `modulePathIgnorePatterns` in `Jest` config.