### PR TITLE
fix: session and internal error classes

### DIFF
--- a/src/Error/InternalServerError.ts
+++ b/src/Error/InternalServerError.ts
@@ -1,7 +1,7 @@
 import { WebDriverError } from './WebDriverError';
 
 export class InternalServerError extends WebDriverError {
-  constructor(message) {
+  constructor() {
     super(500);
     this.name = 'InternalServerError';
   }

--- a/src/Error/SessionNotCreated.ts
+++ b/src/Error/SessionNotCreated.ts
@@ -1,10 +1,10 @@
 import { InternalServerError } from './InternalServerError';
 
 export class SessionNotCreated extends InternalServerError {
-  constructor(message = '') {
-    super(message);
+  constructor(reason?: string) {
+    super();
     this.name = 'SessionNotCreatedError';
     this.JSONCodeError = 'session not created';
-    this.message = 'a new session could not be created';
+    this.message = reason || 'a new session could not be created';
   }
 }

--- a/src/Error/UnableToSetCookie.ts
+++ b/src/Error/UnableToSetCookie.ts
@@ -3,7 +3,6 @@ import { InternalServerError } from './InternalServerError';
 export class UnableToSetCookie extends InternalServerError {
   constructor(reason?: string) {
     super(reason || 'A command to set a cookie’s value could not be satisfied');
-
     this.name = 'UnableToSetCookie';
     this.JSONCodeError = 'unable to set cookie';
   }

--- a/src/Error/UnableToSetCookie.ts
+++ b/src/Error/UnableToSetCookie.ts
@@ -2,7 +2,9 @@ import { InternalServerError } from './InternalServerError';
 
 export class UnableToSetCookie extends InternalServerError {
   constructor(reason?: string) {
-    super(reason || 'A command to set a cookie’s value could not be satisfied');
+    super();
+    this.message =
+      reason || 'A command to set a cookie’s value could not be satisfied';
     this.name = 'UnableToSetCookie';
     this.JSONCodeError = 'unable to set cookie';
   }

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -28,7 +28,6 @@ const {
 import {
   InvalidArgument,
   SessionNotCreated,
-  InternalServerError,
   NoSuchElement,
   ElementNotInteractable,
   NoSuchWindow,
@@ -353,7 +352,7 @@ class Session {
   configureCapabilties(requestedCapabilities) {
     const capabilities = Session.processCapabilities(requestedCapabilities);
     if (capabilities === null)
-      throw new InternalServerError('could not create session');
+      throw new SessionNotCreated('capabilities object is null');
 
     // configure pageLoadStrategy
     if (


### PR DESCRIPTION
- fix formatting in `SessionNotCreated` and `InternalServerError`
- replace throwing `InternalServerError` with `SessionNotCreated` when failed to create session.