### PR TITLE
fix: executeScript endpoint

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -654,7 +654,6 @@ class Session {
       }
     });
 
-    // eslint-disable-next-line no-new-func
     const func = new Function('arguments, window, document', script);
     const {
       window,

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -671,10 +671,10 @@ class Session {
       },
     });
 
-    const createElementAndAddToKnownElements = (value): WebElement => {
+    const createElementAndAddToKnownElements = value => {
       const element = new WebElement(value);
       this.browser.knownElements.push(element);
-      return element;
+      return element.serialize();
     };
 
     let vmReturnValue;

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -646,7 +646,7 @@ class Session {
   /**
    * executes a user defined script within the context of the dom on a given set of user defined arguments
    */
-  public executeScript(script, args) {
+  public executeScript(script: string, args: unknown[]): unknown {
     const argumentList = args.map(arg => {
       if (arg[ELEMENT] == null) {
         return arg;

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -694,11 +694,10 @@ class Session {
       );
     } else if (vmReturnValue instanceof HTMLElement) {
       return createElementAndAddToKnownElements(vmReturnValue);
-    } else if (vmReturnValue === undefined) {
-      return null;
-    } else {
-      return vmReturnValue;
     }
+
+    // client will expect undefined return values to be null
+    return typeof vmReturnValue === 'undefined' ? null : vmReturnValue;
   }
 }
 

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -158,6 +158,7 @@ class Session {
                 .getElementAttribute(urlVariables.attributeName);
               break;
             case COMMANDS.EXECUTE_SCRIPT:
+              if (!this.browser.dom.window) throw new NoSuchWindow();
               response = await this.executeScript(
                 parameters.script,
                 parameters.args,

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -630,14 +630,12 @@ class Session {
    * executes a user defined script within the context of the dom on a given set of user defined arguments
    */
   executeScript(script, args) {
-    const argumentList = [];
-
-    args.forEach(arg => {
-      if (arg[ELEMENT] !== undefined && arg[ELEMENT] !== null) {
-        const element = this.browser.getKnownElement(arg[ELEMENT]);
-        argumentList.push(element.element);
+    const argumentList = args.map(arg => {
+      if (arg[ELEMENT] == null) {
+        const { element } = this.browser.getKnownElement(arg[ELEMENT]);
+        return element;
       } else {
-        argumentList.push(arg);
+        return arg;
       }
     });
 

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -635,7 +635,7 @@ class Session {
   private handleSyncScriptError({
     message,
     code,
-  }: NodeJS.ErrnoException): JavaScriptError | ScriptTimeout {
+  }: NodeJS.ErrnoException): never {
     if (code === 'ERR_SCRIPT_EXECUTION_TIMEOUT') {
       throw new ScriptTimeout();
     } else {

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -633,8 +633,9 @@ class Session {
    */
   private handleSyncScriptError({
     message,
+    code,
   }: NodeJS.ErrnoException): JavaScriptError | ScriptTimeout {
-    if (/timed out/i.test(message)) {
+    if (code === 'ERR_SCRIPT_EXECUTION_TIMEOUT') {
       throw new ScriptTimeout();
     } else {
       throw new JavaScriptError(message);

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -631,13 +631,13 @@ class Session {
   /**
    * handles errors resulting from failing to execute synchronous scripts
    */
-  private handleSyncScriptError(
-    error: NodeJS.ErrnoException,
-  ): JavaScriptError | ScriptTimeout {
-    if (/timed out/i.test(error.code)) {
+  private handleSyncScriptError({
+    message,
+  }: NodeJS.ErrnoException): JavaScriptError | ScriptTimeout {
+    if (/timed out/i.test(message)) {
       throw new ScriptTimeout();
     } else {
-      throw new JavaScriptError(error.message);
+      throw new JavaScriptError(message);
     }
   }
 

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -31,6 +31,8 @@ import {
   NoSuchElement,
   ElementNotInteractable,
   NoSuchWindow,
+  JavaScriptError,
+  ScriptTimeout,
 } from '../Error/errors';
 
 import { CapabilityValidator } from '../CapabilityValidator/CapabilityValidator';
@@ -627,9 +629,22 @@ class Session {
   }
 
   /**
+   * handles errors resulting from failing to execute synchronous scripts
+   */
+  private handleSyncSciptError(
+    error: NodeJS.ErrnoException,
+  ): JavaScriptError | ScriptTimeout {
+    if (/timed out/i.test(error.code)) {
+      throw new ScriptTimeout();
+    } else {
+      throw new JavaScriptError(error.message);
+    }
+  }
+
+  /**
    * executes a user defined script within the context of the dom on a given set of user defined arguments
    */
-  executeScript(script, args) {
+  public executeScript(script, args) {
     const argumentList = args.map(arg => {
       if (arg[ELEMENT] == null) {
         return arg;

--- a/src/WebElement/WebElement.ts
+++ b/src/WebElement/WebElement.ts
@@ -236,6 +236,14 @@ class WebElement {
       throw new InvalidElementState();
     }
   }
+
+  /**
+   * returns the JSON representation of the WebElement
+   * @returns {Object}
+   */
+  public serialize() {
+    return { [ELEMENT]: this[ELEMENT] };
+  }
 }
 
 export { WebElement };


### PR DESCRIPTION
- returns `null` in `undefined` value cases (Closes #20).
- throws `JavaScriptError` and `ScriptTimeout` when appropriate (Closes #72).
- fixes error accessing global `document` and `window` objects (Closes #69).
- serializes `HTMLElement` objects in the correct format (Closes #73).
- refactored and optimized `executeScript` logic. (Closes #66)

Test: `npm run test:compile`