### PR TITLE
fix: jsdom crashing on 401 errors

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -97,12 +97,35 @@ class Browser {
   }
 
   /**
+   * handles errors thrown by the navigation function
+   */
+  private handleNavigationError(error, config) {
+    if (error.statusCode === 401) {
+      const { cookieJar: existingCookieJar } = this.dom;
+
+      this.dom = new JSDOM(' ', {
+        resources: config.resourceLoader,
+        runScripts: config.runScripts,
+        beforeParse: config.beforeParse,
+        pretendToBeVisual: true,
+        cookieJar: existingCookieJar || config.jar,
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  /**
    * accepts a url and pathType @type {String} from which to instantiate the
    * jsdom object
    */
   async navigate(path: URL, pathType) {
     if (path) {
-      await this.configureBrowser(this.browserConfig, path, pathType);
+      try {
+        await this.configureBrowser(this.browserConfig, path, pathType);
+      } catch (error) {
+        this.handleNavigationError(error, this.browserConfig);
+      }
     }
     return true;
   }

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -101,14 +101,12 @@ class Browser {
    */
   private handleNavigationError(error, config) {
     if (error.statusCode === 401) {
-      const { cookieJar: existingCookieJar } = this.dom;
-
       this.dom = new JSDOM(' ', {
         resources: config.resourceLoader,
         runScripts: config.runScripts,
         beforeParse: config.beforeParse,
         pretendToBeVisual: true,
-        cookieJar: existingCookieJar || config.jar,
+        cookieJar: config.jar,
       });
     } else {
       throw error;

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -100,6 +100,7 @@ class Browser {
    * handles errors thrown by the navigation function
    */
   private handleNavigationError(error, config) {
+    // the jsdom instance will otherwise crash on a 401
     if (error.statusCode === 401) {
       this.dom = new JSDOM(' ', {
         resources: config.resourceLoader,


### PR DESCRIPTION
- detect 401 errors and create a new jsdom instance in those cases with current config settings.
- preserve `CookieJar` values.

Test: `npm run test:compile`