### PR TITLE
feat: enable lint-staged to run eslint against .ts files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "*.{json,css,scss,html}": ["prettier --write", "git add"],
   "*.md": ["prettier --write", "markdownlint", "git add"],
-  "*.js": ["eslint --fix", "git add"]
+  "*.{js,ts}": ["eslint --fix", "git add"]
 }


### PR DESCRIPTION
- allows linting of typescript files. Safe to re-enable with new linting rules.