### PR TITLE
fix: global functions not recognized when executing script

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -663,19 +663,16 @@ class Session {
       }
     });
 
-    const func = new Function('arguments, window, document', script);
-    const {
-      window,
-      window: { document },
-    } = this.browser.dom;
+    const { window } = this.browser.dom;
+
+    const func = window
+      .eval(`(function() {${script}})`)
+      .bind(null, ...argumentList);
 
     const vm = new VM({
       timeout: this.timeouts.script,
       sandbox: {
-        window,
-        document,
         func,
-        arguments: argumentList,
       },
     });
 
@@ -688,7 +685,7 @@ class Session {
     let vmReturnValue;
 
     try {
-      vmReturnValue = vm.run('func(arguments, window, document);');
+      vmReturnValue = vm.run('func();');
     } catch (error) {
       this.handleSyncScriptError(error);
     }

--- a/test/jest/execute-script-sync.test.js
+++ b/test/jest/execute-script-sync.test.js
@@ -26,6 +26,15 @@ describe('Execute Script Sync', () => {
               e.textContent = "click success";
             }
           </script>
+          <script>
+            function getTextContent() {
+              return document.querySelector('title').textContent;
+            }
+
+            function getParagraphElement() {
+              return document.querySelector('p');
+            }
+          </script>
         </body>
       </html>`,
       );
@@ -62,12 +71,15 @@ describe('Execute Script Sync', () => {
     expect(value).toBe(true);
   });
 
-  it('returns a resolved promise value', async () => {
+  it('handles Promises', async () => {
     const value = await session.process({
       command: COMMANDS.EXECUTE_SCRIPT,
-      parameters: { script: 'return Promise.resolve("foo");', args: [] },
+      parameters: {
+        script: `return new Promise((resolve) => setTimeout(() => resolve(arguments[0] + ' ' + arguments[1]), 400))`,
+        args: ['hello', 'world!'],
+      },
     });
-    expect(value).toBe('foo');
+    expect(value).toBe('hello world!');
   });
 
   it('sums two arguments', async () => {
@@ -188,5 +200,25 @@ describe('Execute Script Sync', () => {
       },
     });
     expect(buttonText).toBe('click success');
+  });
+
+  it('handles global functions', async () => {
+    const textContent = await session.process({
+      command: COMMANDS.EXECUTE_SCRIPT,
+      parameters: {
+        script: 'return getTextContent();',
+        args: [],
+      },
+    });
+    expect(textContent).toBe('Test Page');
+
+    const paragraphElement = await session.process({
+      command: COMMANDS.EXECUTE_SCRIPT,
+      parameters: {
+        script: 'return getParagraphElement();',
+        args: [],
+      },
+    });
+    expect(paragraphElement).toHaveProperty([ELEMENT], expect.any(String));
   });
 });


### PR DESCRIPTION
- scripts now called using Jsdom's `window.eval` in order to have access to global functions.
- added test for global functions. Improved old Promise test.

Test: `npm run test:compile`

Closes #77.