### PR TITLE
feat: Get Named Cookie endpoint

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -26,7 +26,7 @@ class Browser {
 
   /** accepts a capabilities object with jsdom and plumadriver specific options */
   constructor(capabilities: object) {
-    let browserOptions: Pluma.BrowserOptions = {
+    const browserOptions: Pluma.BrowserOptions = {
       runScripts: '',
       strictSSL: true,
       unhandledPromptBehaviour: 'dismiss and notify',
@@ -48,7 +48,7 @@ class Browser {
   async configureBrowser(
     config: BrowserConfig,
     url: URL | null,
-    pathType: string = 'url',
+    pathType = 'url',
   ) {
     let dom;
 
@@ -261,6 +261,23 @@ class Browser {
     });
 
     return cookies;
+  }
+
+  /**
+   * returns the cookie in the cookie jar matching the requested name
+   */
+  getNamedCookie(requestedName: string): Pluma.Cookie {
+    const { pathname, hostname }: URL = new URL(this.getUrl());
+
+    const requestedCookie = this.getCookies().find(
+      ({ name, path, domain }: Pluma.Cookie): boolean =>
+        name === requestedName &&
+        path === pathname &&
+        hostname.includes(domain),
+    );
+
+    if (!requestedCookie) throw new PlumaError.NoSuchCookie();
+    return requestedCookie;
   }
 
   /**

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -272,7 +272,7 @@ class Browser {
     const requestedCookie = this.getCookies().find(
       ({ name, path, domain }: Pluma.Cookie): boolean =>
         name === requestedName &&
-        path === pathname &&
+        new RegExp(`^${path}`).test(pathname) &&
         hostname.includes(domain),
     );
 

--- a/src/Error/NoSuchCookie.ts
+++ b/src/Error/NoSuchCookie.ts
@@ -1,0 +1,11 @@
+import { NotFoundError } from './NotFoundError';
+
+export class NoSuchCookie extends NotFoundError {
+  constructor() {
+    super();
+    this.message =
+      'No cookie matching the given path name was found amongst the associated cookies of the current browsing context’s active document.';
+    this.name = 'NoSuchCookieError';
+    this.JSONCodeError = 'no such cookie';
+  }
+}

--- a/src/Error/errors.ts
+++ b/src/Error/errors.ts
@@ -10,6 +10,7 @@ import { NoSuchWindow } from './NoSuchWindow';
 import { UnableToSetCookie } from './UnableToSetCookie';
 import { JavaScriptError } from './JavaScriptError';
 import { ScriptTimeout } from './ScriptTimeout';
+import { NoSuchCookie } from './NoSuchCookie';
 
 export {
   MethodNotAllowed,
@@ -24,4 +25,5 @@ export {
   UnableToSetCookie,
   JavaScriptError,
   ScriptTimeout,
+  NoSuchCookie,
 };

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -148,7 +148,7 @@ class Session {
               response = this.browser.addCookie(parameters.cookie);
               break;
             case COMMANDS.GET_NAMED_COOKIE:
-              response = this.browser.getNamedCookie(parameters.name);
+              response = this.browser.getNamedCookie(urlVariables.cookieName);
               break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:
               response = this.browser

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -147,6 +147,9 @@ class Session {
             case COMMANDS.ADD_COOKIE:
               response = this.browser.addCookie(parameters.cookie);
               break;
+            case COMMANDS.GET_NAMED_COOKIE:
+              response = this.browser.getNamedCookie(parameters.name);
+              break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:
               response = this.browser
                 .getKnownElement(urlVariables.elementId)

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -37,6 +37,7 @@ export namespace Pluma {
     httpOnly?: boolean;
     expiry?: number;
     creation?: Date;
+    path?: string;
   }
 
   /**

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -33,7 +33,7 @@ cookies.delete(
   ),
 );
 
-cookies.use((req, res, next) => {
+cookies.use('/:name', (req, res, next) => {
   req.sessionRequest.urlVariables.cookieName = req.params.name;
   next();
 });

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -1,21 +1,58 @@
-
 import * as express from 'express';
 import { COMMANDS } from '../constants/constants';
-import* as utils from '../utils/utils';
-const { defaultSessionEndpointLogic, sessionEndpointExceptionHandler } = utils.endpoint;
+import * as utils from '../utils/utils';
+const {
+  defaultSessionEndpointLogic,
+  sessionEndpointExceptionHandler,
+} = utils.endpoint;
 
 const cookies = express.Router();
 
-cookies.post('/', sessionEndpointExceptionHandler(defaultSessionEndpointLogic,COMMANDS.ADD_COOKIE));
-cookies.get('/', sessionEndpointExceptionHandler(defaultSessionEndpointLogic,COMMANDS.GET_ALL_COOKIES));
+cookies.post(
+  '/',
+  sessionEndpointExceptionHandler(
+    defaultSessionEndpointLogic,
+    COMMANDS.ADD_COOKIE,
+  ),
+);
 
-// TODO: get named cookie
-cookies.post('/:name', sessionEndpointExceptionHandler(defaultSessionEndpointLogic,COMMANDS.GET_NAMED_COOKIE));
-
-// TODO: delete cookie
-cookies.delete('/:name', sessionEndpointExceptionHandler(defaultSessionEndpointLogic,COMMANDS.DELETE_COOKIE));
+cookies.get(
+  '/',
+  sessionEndpointExceptionHandler(
+    defaultSessionEndpointLogic,
+    COMMANDS.GET_ALL_COOKIES,
+  ),
+);
 
 // TODO: delete all cookies
-cookies.delete('/', sessionEndpointExceptionHandler(defaultSessionEndpointLogic,COMMANDS.DELETE_ALL_COOKIES));
+cookies.delete(
+  '/',
+  sessionEndpointExceptionHandler(
+    defaultSessionEndpointLogic,
+    COMMANDS.DELETE_ALL_COOKIES,
+  ),
+);
+
+cookies.use((req, res, next) => {
+  req.sessionRequest.urlVariables.cookieName = req.params.name;
+  next();
+});
+
+cookies.post(
+  '/:name',
+  sessionEndpointExceptionHandler(
+    defaultSessionEndpointLogic,
+    COMMANDS.GET_NAMED_COOKIE,
+  ),
+);
+
+// TODO: delete cookie
+cookies.delete(
+  '/:name',
+  sessionEndpointExceptionHandler(
+    defaultSessionEndpointLogic,
+    COMMANDS.DELETE_COOKIE,
+  ),
+);
 
 export default cookies;

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -38,7 +38,7 @@ cookies.use((req, res, next) => {
   next();
 });
 
-cookies.post(
+cookies.get(
   '/:name',
   sessionEndpointExceptionHandler(
     defaultSessionEndpointLogic,

--- a/test/jest/get-named-cookie.test.js
+++ b/test/jest/get-named-cookie.test.js
@@ -118,7 +118,6 @@ describe('Get Named Cookie', () => {
         cookie: {
           name: 'foo',
           value: 'bar',
-          domain: '.example.com',
           path: '/baz',
         },
       },

--- a/test/jest/get-named-cookie.test.js
+++ b/test/jest/get-named-cookie.test.js
@@ -1,7 +1,7 @@
 const nock = require('nock');
 
 const { Session } = require('../../build/Session/Session');
-const { COMMANDS, ELEMENT } = require('../../build/constants/constants');
+const { COMMANDS } = require('../../build/constants/constants');
 const { NoSuchCookie } = require('../../build/Error/errors');
 
 describe('Get Named Cookie', () => {

--- a/test/jest/get-named-cookie.test.js
+++ b/test/jest/get-named-cookie.test.js
@@ -1,0 +1,138 @@
+const nock = require('nock');
+
+const { Session } = require('../../build/Session/Session');
+const { COMMANDS, ELEMENT } = require('../../build/constants/constants');
+const { NoSuchCookie } = require('../../build/Error/errors');
+
+describe('Get Named Cookie', () => {
+  let session;
+
+  beforeEach(async () => {
+    nock(/plumadriver/)
+      .get(/\/\.*/)
+      .reply(200, '<html></html>');
+
+    const requestBody = {
+      desiredCapabilities: {
+        browserName: 'pluma',
+        unhandledPromptBehavior: 'ignore',
+        'plm:plumaOptions': { runScripts: true },
+      },
+      capabilities: {
+        firstMatch: [
+          {
+            browserName: 'pluma',
+            'plm:plumaOptions': { runScripts: true },
+            unhandledPromptBehavior: 'ignore',
+          },
+        ],
+      },
+    };
+
+    session = new Session(requestBody);
+  });
+
+  const navigateTo = async url => {
+    await session.process({
+      command: COMMANDS.NAVIGATE_TO,
+      parameters: { url },
+    });
+  };
+
+  it('gets an existing cookie by name', async () => {
+    await navigateTo('http://plumadriver.com');
+    await session.process({
+      command: COMMANDS.ADD_COOKIE,
+      parameters: {
+        cookie: {
+          name: 'foo',
+          value: 'bar',
+          domain: '.plumadriver.com',
+        },
+      },
+    });
+
+    const { name, value } = await session.process({
+      command: COMMANDS.GET_NAMED_COOKIE,
+      urlVariables: { cookieName: 'foo' },
+    });
+
+    expect(name).toBe('foo');
+    expect(value).toBe('bar');
+  });
+
+
+  it('respects matching cookie paths', async () => {
+    await navigateTo('http://plumadriver.com/a/b');
+    await session.process({
+      command: COMMANDS.ADD_COOKIE,
+      parameters: {
+        cookie: {
+          name: 'foo',
+          value: 'bar',
+          domain: '.plumadriver.com',
+          path: '/a'
+        },
+      },
+    });
+
+    const { name, value } = await session.process({
+      command: COMMANDS.GET_NAMED_COOKIE,
+      urlVariables: { cookieName: 'foo' },
+    });
+
+    expect(name).toBe('foo');
+    expect(value).toBe('bar');
+  });
+
+  it('throws NoSuchCookie on mismatched domain', async () => {
+    await navigateTo('http://plumadriver.com');
+    await session.process({
+      command: COMMANDS.ADD_COOKIE,
+      parameters: {
+        cookie: {
+          name: 'foo',
+          value: 'bar',
+          domain: '.example.com',
+        },
+      },
+    });
+
+    expect.assertions(1);
+
+    await session
+      .process({
+        command: COMMANDS.GET_NAMED_COOKIE,
+        urlVariables: { cookieName: 'foo' },
+      })
+      .catch(e => {
+        expect(e).toBeInstanceOf(NoSuchCookie);
+      });
+  });
+
+  it('throws NoSuchCookie on mismatched path', async () => {
+    await navigateTo('http://plumadriver.com');
+    await session.process({
+      command: COMMANDS.ADD_COOKIE,
+      parameters: {
+        cookie: {
+          name: 'foo',
+          value: 'bar',
+          domain: '.example.com',
+          path: '/baz',
+        },
+      },
+    });
+
+    expect.assertions(1);
+
+    await session
+      .process({
+        command: COMMANDS.GET_NAMED_COOKIE,
+        urlVariables: { cookieName: 'foo' },
+      })
+      .catch(e => {
+        expect(e).toBeInstanceOf(NoSuchCookie);
+      });
+  });
+});


### PR DESCRIPTION
- adds ability to retrieve a cookie by name in the context of the current active document.
- fixed express logic to handle `name` route param.
- created `NoSuchCookie` error.
- added tests for endpoint.
- some diffs are due to `prettier` formatting.

Closes #84.