### PR TITLE
feat: delete cookie endpoints

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -296,7 +296,7 @@ class Browser {
             pattern.test(cookie.name) && this.isAssociatedCookie(cookie),
         )
         .forEach(({ domain, path, name }: Pluma.Cookie): void => {
-          this.dom.cookieJar.store(domain, path, name, err => {
+          this.dom.cookieJar.store.removeCookie(domain, path, name, err => {
             if (err) reject(err);
           });
         });

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -289,7 +289,7 @@ class Browser {
    * delete associated cookies from the cookie jar matching a regexp pattern
    */
   public deleteCookies(pattern: RegExp): Promise<void> {
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve, reject) => {
       this.getCookies()
         .filter(
           (cookie: Pluma.Cookie): boolean =>
@@ -297,7 +297,7 @@ class Browser {
         )
         .forEach(({ domain, path, name }: Pluma.Cookie): void => {
           this.dom.cookieJar.store(domain, path, name, err => {
-            if (err) throw err;
+            if (err) reject(err);
           });
         });
       resolve();

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -264,16 +264,21 @@ class Browser {
   }
 
   /**
+   * returns true if the cookie is associated with the current
+   * browsing context's active document
+   */
+  private isAssociatedCookie({ path, domain }: Pluma.Cookie): boolean {
+    const { pathname, hostname }: URL = new URL(this.getUrl());
+    return new RegExp(`^${path}`).test(pathname) && hostname.includes(domain);
+  }
+
+  /**
    * returns the cookie in the cookie jar matching the requested name
    */
-  getNamedCookie(requestedName: string): Pluma.Cookie {
-    const { pathname, hostname }: URL = new URL(this.getUrl());
-
+  public getNamedCookie(requestedName: string): Pluma.Cookie {
     const requestedCookie = this.getCookies().find(
-      ({ name, path, domain }: Pluma.Cookie): boolean =>
-        name === requestedName &&
-        new RegExp(`^${path}`).test(pathname) &&
-        hostname.includes(domain),
+      (cookie: Pluma.Cookie): boolean =>
+        cookie.name === requestedName && this.isAssociatedCookie(cookie),
     );
 
     if (!requestedCookie) throw new PlumaError.NoSuchCookie();
@@ -281,10 +286,23 @@ class Browser {
   }
 
   /**
-   * deletes associated cookies from the cookie jar matching a pattern.
-   * If pattern is undefined, then all cookies are deleted.
+   * delete associated cookies from the cookie jar matching a regexp pattern
    */
-  deleteCookies(pattern?: string): void {}
+  public deleteCookies(pattern: RegExp): Promise<void> {
+    return new Promise<void>(resolve => {
+      this.getCookies()
+        .filter(
+          (cookie: Pluma.Cookie): boolean =>
+            pattern.test(cookie.name) && this.isAssociatedCookie(cookie),
+        )
+        .forEach(({ domain, path, name }: Pluma.Cookie): void => {
+          this.dom.cookieJar.store(domain, path, name, err => {
+            if (err) throw err;
+          });
+        });
+      resolve();
+    });
+  }
 
   /**
    * @param elementId @type {string} the id of a known element in the known element list

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -281,6 +281,12 @@ class Browser {
   }
 
   /**
+   * deletes associated cookies from the cookie jar matching a pattern.
+   * If pattern is undefined, then all cookies are deleted.
+   */
+  deleteCookies(pattern?: string): void {}
+
+  /**
    * @param elementId @type {string} the id of a known element in the known element list
    */
   getKnownElement(elementId: string): WebElement {

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -151,9 +151,15 @@ class Session {
               if (!this.browser.dom.window) throw new NoSuchWindow();
               response = this.browser.getNamedCookie(urlVariables.cookieName);
               break;
+            case COMMANDS.DELETE_COOKIE:
+              if (!this.browser.dom.window) throw new NoSuchWindow();
+              response = this.browser.deleteCookies(
+                new RegExp(`^${urlVariables.cookieName}$`),
+              );
+              break;
             case COMMANDS.DELETE_ALL_COOKIES:
               if (!this.browser.dom.window) throw new NoSuchWindow();
-              response = this.browser.deleteCookies();
+              response = this.browser.deleteCookies(/.*/);
               break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:
               response = this.browser
@@ -250,12 +256,12 @@ class Session {
           element.getAttribute('type') === 'text' ||
           element.getAttribute('type') === 'email'
         ) {
-          element.value += text;
+          (element as HTMLInputElement).value += text;
           element.dispatchEvent(new Event('input'));
           element.dispatchEvent(new Event('change'));
         } else if (element.getAttribute('type') === 'color') {
           if (!validator.isHexColor(text)) throw new InvalidArgument();
-          element.value = text;
+          (element as HTMLInputElement).value = text;
         } else {
           if (
             !Object.prototype.hasOwnProperty.call(element, 'value') ||
@@ -263,7 +269,7 @@ class Session {
           )
             throw new Error('element not interactable'); // TODO: create error class
           // TODO: add check to see if element is mutable, reject with element not interactable
-          element.value = text;
+          (element as HTMLInputElement).value = text;
         }
         element.dispatchEvent(new Event('input'));
         element.dispatchEvent(new Event('change'));

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -153,13 +153,13 @@ class Session {
               break;
             case COMMANDS.DELETE_COOKIE:
               if (!this.browser.dom.window) throw new NoSuchWindow();
-              response = this.browser.deleteCookies(
+              await this.browser.deleteCookies(
                 new RegExp(`^${urlVariables.cookieName}$`),
               );
               break;
             case COMMANDS.DELETE_ALL_COOKIES:
               if (!this.browser.dom.window) throw new NoSuchWindow();
-              response = this.browser.deleteCookies(/.*/);
+              await this.browser.deleteCookies(/.*/);
               break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:
               response = this.browser

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -56,7 +56,7 @@ class Session {
    * a queue of [[Pluma.Request]] currently awaiting processsing
    *  */
   mutex: Mutex;
-  proxy: Record<string, any> | null;
+  proxy: Record<string, unknown> | null;
 
   constructor(requestBody) {
     this.id = uuidv1();
@@ -153,7 +153,7 @@ class Session {
               break;
             case COMMANDS.DELETE_ALL_COOKIES:
               if (!this.browser.dom.window) throw new NoSuchWindow();
-              response = this.browser.deleteAllCookies();
+              response = this.browser.deleteCookies();
               break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:
               response = this.browser
@@ -215,7 +215,7 @@ class Session {
   sendKeysToElement(text: string, elementId: string) {
     return new Promise(async (resolve, reject) => {
       const webElement = this.browser.getKnownElement(elementId);
-      const element: any = webElement.element;
+      const element: HTMLElement = webElement.element;
       let files = [];
 
       if (text === undefined) reject(new InvalidArgument());

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -150,6 +150,9 @@ class Session {
             case COMMANDS.GET_NAMED_COOKIE:
               response = this.browser.getNamedCookie(urlVariables.cookieName);
               break;
+            case COMMANDS.DELETE_ALL_COOKIES:
+              response = this.browser.deleteAllCookies();
+              break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:
               response = this.browser
                 .getKnownElement(urlVariables.elementId)

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -148,9 +148,11 @@ class Session {
               response = this.browser.addCookie(parameters.cookie);
               break;
             case COMMANDS.GET_NAMED_COOKIE:
+              if (!this.browser.dom.window) throw new NoSuchWindow();
               response = this.browser.getNamedCookie(urlVariables.cookieName);
               break;
             case COMMANDS.DELETE_ALL_COOKIES:
+              if (!this.browser.dom.window) throw new NoSuchWindow();
               response = this.browser.deleteAllCookies();
               break;
             case COMMANDS.GET_ELEMENT_TAG_NAME:

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -24,7 +24,6 @@ cookies.get(
   ),
 );
 
-// TODO: delete all cookies
 cookies.delete(
   '/',
   sessionEndpointExceptionHandler(

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -45,7 +45,6 @@ cookies.get(
   ),
 );
 
-// TODO: delete cookie
 cookies.delete(
   '/:name',
   sessionEndpointExceptionHandler(

--- a/test/jest/delete-cookie.test.js
+++ b/test/jest/delete-cookie.test.js
@@ -104,4 +104,18 @@ describe('Delete Cookie', () => {
       'also not associated',
     ]);
   });
+
+  it('does not throw error on missing cookie name', async () => {
+    await navigateTo('http://plumadriver.com');
+    await addCookie('foo', '.pluma.com', '/');
+
+    await session.process({
+      command: COMMANDS.DELETE_COOKIE,
+      urlVariables: { cookieName: 'baz' },
+    });
+
+    const cookies = await session.process({
+      command: COMMANDS.GET_ALL_COOKIES,
+    });
+  });
 });

--- a/test/jest/delete-cookie.test.js
+++ b/test/jest/delete-cookie.test.js
@@ -105,7 +105,7 @@ describe('Delete Cookie', () => {
     ]);
   });
 
-  it('does not throw error on missing cookie name', async () => {
+  it('does not throw error on mismatched cookie name', async () => {
     await navigateTo('http://plumadriver.com');
     await addCookie('foo', '.pluma.com', '/');
 

--- a/test/jest/delete-cookie.test.js
+++ b/test/jest/delete-cookie.test.js
@@ -1,0 +1,107 @@
+const nock = require('nock');
+
+const { Session } = require('../../build/Session/Session');
+const { COMMANDS } = require('../../build/constants/constants');
+
+describe('Delete Cookie', () => {
+  let session;
+
+  beforeEach(async () => {
+    nock(/plumadriver/)
+      .get(/\/\.*/)
+      .reply(200, '<html></html>');
+
+    const requestBody = {
+      desiredCapabilities: {
+        browserName: 'pluma',
+        unhandledPromptBehavior: 'ignore',
+        'plm:plumaOptions': { runScripts: true },
+      },
+      capabilities: {
+        firstMatch: [
+          {
+            browserName: 'pluma',
+            'plm:plumaOptions': { runScripts: true },
+            unhandledPromptBehavior: 'ignore',
+          },
+        ],
+      },
+    };
+
+    session = new Session(requestBody);
+  });
+
+  const navigateTo = async url => {
+    await session.process({
+      command: COMMANDS.NAVIGATE_TO,
+      parameters: { url },
+    });
+  };
+
+  const addCookie = async (name, domain, path = '/', value = 'bar') => {
+    await session.process({
+      command: COMMANDS.ADD_COOKIE,
+      parameters: {
+        cookie: {
+          name,
+          domain,
+          path,
+          value,
+        },
+      },
+    });
+  };
+
+  it('deletes an existing cookie by name', async () => {
+    await navigateTo('http://plumadriver.com');
+    await addCookie('foo', '.plumadriver.com');
+
+    await session.process({
+      command: COMMANDS.DELETE_COOKIE,
+      urlVariables: { cookieName: 'foo' },
+    });
+
+    const cookies = await session.process({
+      command: COMMANDS.GET_ALL_COOKIES,
+    });
+
+    expect(cookies).toStrictEqual([]);
+  });
+
+  it('does not delete an unassociated cookie', async () => {
+    await navigateTo('http://plumadriver.com');
+    await addCookie('foo', '.pluma.com');
+
+    await session.process({
+      command: COMMANDS.DELETE_COOKIE,
+      urlVariables: { cookieName: 'foo' },
+    });
+
+    const cookies = await session.process({
+      command: COMMANDS.GET_ALL_COOKIES,
+    });
+
+    expect(cookies).not.toStrictEqual([]);
+  });
+
+  it('deletes all associated cookies', async () => {
+    await navigateTo('http://plumadriver.com');
+    await addCookie('not associated', '.pluma.com', '/');
+    await addCookie('also not associated', '.plumadriver.com', '/plumadriver');
+    await addCookie('associated', '.plumadriver.com', '/');
+    await addCookie('also associated', '.plumadriver.com');
+
+    await session.process({
+      command: COMMANDS.DELETE_ALL_COOKIES,
+    });
+
+    const cookies = await session.process({
+      command: COMMANDS.GET_ALL_COOKIES,
+    });
+
+    expect(cookies.map(({ name }) => name)).toStrictEqual([
+      'not associated',
+      'also not associated',
+    ]);
+  });
+});


### PR DESCRIPTION
- added `Delete Cookie` endpoint (Closes #86).
- added `Delete All Cookies` endpoint (Closes #85).
- added tests (`npm run test:compile`).
- some diffs were needed to make older code pass typescript linting rules. (progress toward #32). 