### PR TITLE
fix: change execute script return value in session process

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -173,10 +173,11 @@ class Session {
               break;
             case COMMANDS.EXECUTE_SCRIPT:
               if (!this.browser.dom.window) throw new NoSuchWindow();
-              response = await this.executeScript(
+              const value: unknown = await this.executeScript(
                 parameters.script,
                 parameters.args,
               );
+              response = { value };
               break;
             case COMMANDS.ELEMENT_SEND_KEYS:
               await this.sendKeysToElement(


### PR DESCRIPTION
- Fixes how `execute script` responses are handled. 
- Fixes error when processing certain falsy values (Closes #79).

Note: some tests will fail since they expect the old format. This will be fixed by #96.