### PR TITLE
fix: correct NodeList and HTMLCollection handling in execute script

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -712,6 +712,15 @@ class Session {
       this.handleSyncScriptError(error);
     }
 
+    const { NodeList, HTMLCollection } = window;
+
+    if (
+      vmReturnValue instanceof NodeList ||
+      vmReturnValue instanceof HTMLCollection
+    ) {
+      vmReturnValue = Array.from(vmReturnValue);
+    }
+
     if (Array.isArray(vmReturnValue)) {
       return vmReturnValue.map(value =>
         value instanceof HTMLElement

--- a/test/jest/e2e/execute-script-sync.test.js
+++ b/test/jest/e2e/execute-script-sync.test.js
@@ -19,6 +19,7 @@ describe('Execute Script Sync', () => {
         </head>
         <body>
           <input type="text" value='baz' />
+          <input type="password" />
           <p id="foo">bar</p>
           <button onclick="clickAction(this)">
             not clicked
@@ -29,8 +30,8 @@ describe('Execute Script Sync', () => {
             }
           </script>
           <script>
-            function getInputValue() {
-              return document.querySelector('input').value;
+            function getTextInputValue() {
+              return document.querySelector('input[type="text"]').value;
             }
 
             function getParagraphElement() {
@@ -155,7 +156,7 @@ describe('Execute Script Sync', () => {
   });
 
   it('handles global functions', async () => {
-    expect(await executeScript('return getInputValue()')).toBe('baz');
+    expect(await executeScript('return getTextInputValue()')).toBe('baz');
     expect(await executeScript('return getParagraphElement();')).toHaveProperty(
       [ELEMENT],
       expect.any(String),
@@ -165,7 +166,10 @@ describe('Execute Script Sync', () => {
   it('handles NodeList and HTMLCollection', async () => {
     expect(
       await executeScript('return document.querySelectorAll("input")'),
-    ).toStrictEqual([{ [ELEMENT]: expect.any(String) }]);
+    ).toStrictEqual([
+      { [ELEMENT]: expect.any(String) },
+      { [ELEMENT]: expect.any(String) },
+    ]);
 
     expect(
       await executeScript('return document.getElementsByTagName("body")'),

--- a/test/jest/e2e/execute-script-sync.test.js
+++ b/test/jest/e2e/execute-script-sync.test.js
@@ -155,11 +155,20 @@ describe('Execute Script Sync', () => {
   });
 
   it('handles global functions', async () => {
-    expect(await executeScript('return getInputValue()')).toBe(
-      'baz',
+    expect(await executeScript('return getInputValue()')).toBe('baz');
+    expect(await executeScript('return getParagraphElement();')).toHaveProperty(
+      [ELEMENT],
+      expect.any(String),
     );
+  });
+
+  it('handles NodeList and HTMLCollection', async () => {
     expect(
-      await executeScript('return getParagraphElement();'),
-    ).toHaveProperty([ELEMENT], expect.any(String));
+      await executeScript('return document.querySelectorAll("input")'),
+    ).toStrictEqual([{ [ELEMENT]: expect.any(String) }]);
+
+    expect(
+      await executeScript('return document.getElementsByTagName("body")'),
+    ).toStrictEqual([{ [ELEMENT]: expect.any(String) }]);
   });
 });


### PR DESCRIPTION
- `NodeList` and `HTMLCollection` objects are converted to arrays before they are handled.
- added new tests for this bug: `npm run compile && npm test e2e/execute-script`

Closes #104 