### PR TITLE
fix: use package.json version for browserVersion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8336,6 +8336,11 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pjson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/pjson/-/pjson-1.0.9.tgz",
+      "integrity": "sha512-4hRJH3YzkUpOlShRzhyxAmThSNnAaIlWZCAb27hd0pVUAXNUAHAO7XZbsPPvsCYwBFEScTmCCL6DGE8NyZ8BdQ=="
+    },
     "pkg": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mime-types": "^2.1.24",
     "minimist": "^1.2.0",
     "os": "^0.1.1",
+    "pjson": "^1.0.9",
     "request": "^2.88.0",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "uuid": "^3.3.2",

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -535,7 +535,7 @@ class Session {
   static matchCapabilities(capabilties) {
     const matchedCapabilities = {
       browserName: 'pluma',
-      browserVersion: 'v1.0',
+      browserVersion: utils.getVersion(),
       platformName: os.platform(),
       acceptInsecureCerts: false,
       setWindowRect: false,

--- a/src/SessionManager/SessionManager.ts
+++ b/src/SessionManager/SessionManager.ts
@@ -2,6 +2,7 @@ import * as os from 'os';
 import { Session } from '../Session/Session';
 import { NotFoundError } from '../Error/errors';
 import { Pluma } from '../Types/types';
+import { getVersion } from '../utils/utils';
 
 /**
  * manages the life and death of all Session objects
@@ -39,7 +40,7 @@ class SessionManager {
         sessionId: session.id,
         capabilities: {
           browserName: 'pluma',
-          browserVersion: 'v1.0',
+          browserVersion: getVersion(),
           platformName: os.platform(),
           acceptInsecureCerts: session.secureTLS,
           setWindowRect: false,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,6 +2,7 @@ import { Pluma } from '../Types/types';
 import * as PlumaError from '../Error/errors';
 import * as fs from 'fs';
 import * as isDisplayedAtom from './isdisplayed-atom.json';
+import { version } from 'pjson';
 
 // credit where it's due: https://stackoverflow.com/questions/36836011/checking-validity-of-string-literal-union-type-at-runtime/43621735
 export const StringUnion = <UnionType extends string>(
@@ -186,3 +187,6 @@ export const isString = (candidateValue): boolean =>
 
 export const isBoolean = (candidateValue): boolean =>
   typeof candidateValue === 'boolean';
+
+// Expose the version in package.json
+export const getVersion = (): string => `v${version}`;

--- a/test/jest/e2e/session.test.js
+++ b/test/jest/e2e/session.test.js
@@ -35,7 +35,7 @@ describe('Session', () => {
         capabilities: {
           acceptInsecureCerts: false,
           browserName: 'pluma',
-          browserVersion: expect.any(String),
+          browserVersion: expect.stringMatching(/^v\d+(\.\d+)*$/),
           pageLoadStrategy: 'normal',
           platformName: expect.any(String),
           unhandledPromptBehaviour: 'ignore',

--- a/test/jest/utils/utils.test.js
+++ b/test/jest/utils/utils.test.js
@@ -1,4 +1,5 @@
-const { extractDomainFromUrl } = require('../../../build/utils/utils');
+const { extractDomainFromUrl, getVersion } = require('../../../build/utils/utils');
+const { version } = require('../../../package.json');
 
 describe('Utils Functions', () => {
   it('extractDomainFromString parses urls', () => {
@@ -7,5 +8,9 @@ describe('Utils Functions', () => {
     expect(extractDomainFromUrl('http://foo.example.com/path/to/page?name=ferret&color=purple')).toEqual('foo.example.com');
     expect(extractDomainFromUrl('ftp://127.0.0.1:5500/index.html#foo?bar=baz')).toEqual('127.0.0.1');
     expect(extractDomainFromUrl('https://www.company.gov.on.ca/Jobs.aspx')).toEqual('www.company.gov.on.ca');
+  })
+
+  it('getVersion returns current version in package.json', () => {
+    expect(getVersion()).toEqual(`v${version}`);
   })
 })


### PR DESCRIPTION
This fixes #113, adding a new module `utils/version`, which exposes a `getVersion()` function to return a `String` of the form `v0.5.0`.  Because this needs to include version info from `package.json`, which is outside the `rootDir`, I needed a workaround to load this file at compile time.  Different projects do this in different ways (e.g., [Facebook uses `require()` in Jest](https://github.com/facebook/jest/blob/master/packages/jest-core/src/version.ts)), but I opted for using a dependency-free module ([psjon](https://github.com/serkanyersen/pjson)) that does exactly what I wanted without needing to modify a lot of your config.

NOTE: the tests are broken for me, so I can't fully test this locally--all tests fail with:

```
  ● Test suite failed to run

    The name `tough-cookie` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or blacklist files until there remains only one of these:

      * `/Users/humphd/repos/plumadriver/build/build/jsdom_extensions/tough-cookie/package.json` (package)
      * `/Users/humphd/repos/plumadriver/build/jsdom_extensions/tough-cookie/package.json` (package)
      * `/Users/humphd/repos/plumadriver/build/src/jsdom_extensions/tough-cookie/package.json` (package)

      at ModuleMap._assertNoDuplicates (node_modules/jest-haste-map/build/ModuleMap.js:280:11)
      at Object.<anonymous> (node_modules/jsdom/lib/api.js:5:21)
```

If you can advise me on how to fix this, I'll do more testing locally. 