### PR TITLE
fix: update compile command in npm watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build:macos": "tsc && pkg . --target latest-mac-x64",
     "build:all": "tsc && pkg . --target latest-linux-x64,latest-win-x64,latest-mac-x64",
     "generate-docs": "./node_modules/.bin/typedoc --out docs ./src/ --options ./typedoc.json &>/dev/null",
-    "watch": "nodemon --watch src/ --exec 'npm run compile-ts && npm start' -e ts",
+    "watch": "nodemon --watch src/ --exec 'npm run compile && npm start' -e ts",
     "commit": "git cz",
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."


### PR DESCRIPTION
Fixes #89, updating compile script invocation from `compile-ts` to `compile`.

One note for the future: devs on Windows may have problems with `&&` in npm scripts.  It's better to use [npm-run-all](https://www.npmjs.com/package/npm-run-all), which exposes `run-s` and `run-p` for sequential or parallel running of multiple scripts, giving a cross-platform way to do `&&` safely.