### PR TITLE
feat: shutdown endpoint

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -55,7 +55,6 @@ router.delete('/session/:sessionId', async (req, res, next) => {
     req.sessionRequest.command = COMMANDS.DELETE_SESSION;
     await sessionManager.deleteSession(req.session, req.sessionRequest);
     res.send(null);
-    if (sessionManager.sessions.length === 0) process.exit(0);
   } catch (error) {
     next(error);
   } finally {
@@ -122,5 +121,10 @@ router.use(
   },
   element,
 );
+
+router.get('/shutdown', (req, res) => {
+  res.json({ value: null });
+  process.exit(0);
+});
 
 export default router;

--- a/test/jest/e2e/shutdown.test.js
+++ b/test/jest/e2e/shutdown.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+
+const { app } = require('../../../build/app');
+const { createSession } = require('./helpers');
+
+describe('Shutdown', () => {
+  it('exits a PlumaDriver process', async () => {
+    await createSession(request, app);
+    let isProcessTerminated = false;
+
+    jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => (isProcessTerminated = true));
+
+    const {
+      body: { value },
+    } = await request(app)
+      .get(`/shutdown`)
+      .expect(200);
+
+    expect(value).toBe(null);
+    expect(isProcessTerminated).toBe(true);
+  });
+});


### PR DESCRIPTION
- Adds an endpoint (non-W3C) used by Selenium to shutdown a driver instance.
- Fixes #116. Process will no longer exit due to an empty sessions list.

Test: `npm run compile && npm test e2e/shutdown`
