### PR TITLE
refactor: remove unnecessary NODE_ENV assignment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { app } from './app';
 
 const args = argv(process.argv.slice(2));
 const HTTP_PORT = process.env.PORT || args.port || 3000;
-process.env.NODE_ENV = process.env.NODE_ENV || 'dev';
 
 app.listen(HTTP_PORT, () => {
   console.log(`plumadriver is listening on port ${HTTP_PORT}`);


### PR DESCRIPTION
This line appears to have no purpose. Reading `process.env` variables also carries a performance penalty so it is best we remove this.