### PR TITLE
fix: error in lintstaged config affecting markdown files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,4 @@
 {
-  "*.{json,css,scss,html}": ["prettier --write", "git add"],
-  "*.md": ["prettier --write", "markdownlint", "git add"],
+  "*.{json,css,scss,html,md}": ["prettier --write", "git add"],
   "*.{js,ts}": ["eslint --fix", "git add"]
 }


### PR DESCRIPTION
- fixed bug where `.md` files would be evaluated by non-existent `markdownlint`.