### PR TITLE
refactor: remove unnecessary constant variable in bin.js

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,2 +1,2 @@
 process.env.NODE_ENV = 'production';
-const plumadriver = require('./build');
+require('./build');


### PR DESCRIPTION
- the `plumadriver` variable is not needed when building with `pkg`
- this prevents running into a linter error with `npm run lint`