### PR TITLE
fix: correct returning newlines in execute script sync

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -690,9 +690,12 @@ class Session {
     });
 
     const { window } = this.browser.dom;
+    const scriptWithEscapedNewlines = script
+      .replace(/\r\n/g, '\\r\\n')
+      .replace(/\n/g, '\\n');
 
     const func = window
-      .eval(`(function() {${script}})`)
+      .eval(`(function() {${scriptWithEscapedNewlines}})`)
       .bind(null, ...argumentList);
 
     const vm = new VM({

--- a/test/jest/e2e/execute-script-sync.test.js
+++ b/test/jest/e2e/execute-script-sync.test.js
@@ -175,4 +175,10 @@ describe('Execute Script Sync', () => {
       await executeScript('return document.getElementsByTagName("body")'),
     ).toStrictEqual([{ [ELEMENT]: expect.any(String) }]);
   });
+
+  it('handles returning newlines', async () => {
+    expect(await executeScript('return "\n"')).toBe('\n');
+    expect(await executeScript('return "\r\n"')).toBe('\r\n');
+    expect(await executeScript('return "\n\r\n\r\n";')).toBe('\n\r\n\r\n');
+  });
 });


### PR DESCRIPTION
- fixes #107: error caused by attempting to return newline in execute script sync.

Test: `npm test e2e/execute` 