### PR TITLE
Revert "fix: correct returning newlines in execute script sync"

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -690,12 +690,9 @@ class Session {
     });
 
     const { window } = this.browser.dom;
-    const scriptWithEscapedNewlines = script
-      .replace(/\r\n/g, '\\r\\n')
-      .replace(/\n/g, '\\n');
 
     const func = window
-      .eval(`(function() {${scriptWithEscapedNewlines}})`)
+      .eval(`(function() {${script}})`)
       .bind(null, ...argumentList);
 
     const vm = new VM({

--- a/test/jest/e2e/execute-script-sync.test.js
+++ b/test/jest/e2e/execute-script-sync.test.js
@@ -175,10 +175,4 @@ describe('Execute Script Sync', () => {
       await executeScript('return document.getElementsByTagName("body")'),
     ).toStrictEqual([{ [ELEMENT]: expect.any(String) }]);
   });
-
-  it('handles returning newlines', async () => {
-    expect(await executeScript('return "\n"')).toBe('\n');
-    expect(await executeScript('return "\r\n"')).toBe('\r\n');
-    expect(await executeScript('return "\n\r\n\r\n";')).toBe('\n\r\n\r\n');
-  });
 });


### PR DESCRIPTION
- Recommend reverting this for the time being. While this fixes newline character return values, it causes errors in some scripts where newlines are used for spacing by Selenium.