### PR TITLE
refactor: support current browsing context

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -17,12 +17,18 @@ import { Cookie } from '../jsdom_extensions/tough-cookie/lib/cookie';
 class Browser {
   /** contains the user-defined jsdom configuration object for the session */
   browserConfig: BrowserConfig;
+
   /** the [list of known elements](https://www.w3.org/TR/webdriver1/#elements) */
   knownElements: Array<WebElement> = [];
+
   /** the jsdom object */
   dom: JSDOM;
+
   /** the user-agent's active element */
   activeElement: HTMLElement | null;
+
+  /** the Window of the current browsing context */
+  currentBrowsingContextWindow: Window;
 
   /** accepts a capabilities object with jsdom and plumadriver specific options */
   constructor(capabilities: object) {

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -24,9 +24,6 @@ class Browser {
   /** the jsdom object */
   dom: JSDOM;
 
-  /** the user-agent's active element */
-  activeElement: HTMLElement | null;
-
   /** the Window of the current browsing context */
   currentBrowsingContextWindow: Window;
 
@@ -97,9 +94,12 @@ class Browser {
       });
     }
 
+    const { window } = this.dom;
+
     // webdriver-active property (W3C)
-    this.dom.window.navigator.webdriver = true;
-    this.activeElement = this.dom.window.document.activeElement;
+    window.navigator.webdriver = true;
+
+    this.currentBrowsingContextWindow = window;
   }
 
   /**
@@ -149,6 +149,15 @@ class Browser {
    */
   getUrl() {
     return this.dom.window.document.URL;
+  }
+
+  /**
+   * returns the currently focused element
+   * @returns {HTMLElement}
+   */
+  getActiveElement(): HTMLElement {
+    return this.currentBrowsingContextWindow.document
+      .activeElement as HTMLElement;
   }
 
   private createCookieJarOptions(

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -25,7 +25,7 @@ class Browser {
   dom: JSDOM;
 
   /** the Window of the current browsing context */
-  currentBrowsingContextWindow: Window;
+  private currentBrowsingContextWindow: Window;
 
   /** accepts a capabilities object with jsdom and plumadriver specific options */
   constructor(capabilities: object) {
@@ -99,7 +99,7 @@ class Browser {
     // webdriver-active property (W3C)
     window.navigator.webdriver = true;
 
-    this.currentBrowsingContextWindow = window;
+    this.setCurrentBrowsingContextWindow(window);
   }
 
   /**
@@ -136,26 +136,42 @@ class Browser {
   }
 
   /**
-   * Returns the current page title
+   * Get the current page title.
    * @returns {String}
    */
-  getTitle(): string {
+  public getTitle(): string {
     return this.currentBrowsingContextWindow.document.title;
   }
 
   /**
-   * returns the current page url
+   * Get the current page url.
    * @returns {String}
    */
-  getUrl(): string {
+  public getUrl(): string {
     return this.currentBrowsingContextWindow.document.URL;
   }
 
   /**
-   * returns the currently focused element
+   * Get the Window object associated with the current browsing context.
+   * @returns {Window}
+   */
+  public getCurrentBrowsingContextWindow(): Window {
+    return this.currentBrowsingContextWindow;
+  }
+
+  /**
+   * Set the Window for the current browsing context.
+   * @param {Window} window - the Window object
+   */
+  public setCurrentBrowsingContextWindow(window: Window) {
+    this.currentBrowsingContextWindow = window;
+  }
+
+  /**
+   * Get the currently focused element.
    * @returns {HTMLElement}
    */
-  getActiveElement(): HTMLElement {
+  public getActiveElement(): HTMLElement {
     return this.currentBrowsingContextWindow.document
       .activeElement as HTMLElement;
   }

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -139,16 +139,16 @@ class Browser {
    * Returns the current page title
    * @returns {String}
    */
-  getTitle() {
-    return this.dom.window.document.title;
+  getTitle(): string {
+    return this.currentBrowsingContextWindow.document.title;
   }
 
   /**
    * returns the current page url
    * @returns {String}
    */
-  getUrl() {
-    return this.dom.window.document.URL;
+  getUrl(): string {
+    return this.currentBrowsingContextWindow.document.URL;
   }
 
   /**

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -99,7 +99,7 @@ class Session {
         break;
       case COMMANDS.FIND_ELEMENT:
         response = this.elementRetrieval(
-          this.browser.dom.window.document,
+          this.browser.currentBrowsingContextWindow.document,
           parameters.using,
           parameters.value,
         )[0];
@@ -107,7 +107,7 @@ class Session {
         break;
       case COMMANDS.FIND_ELEMENTS:
         response = this.elementRetrieval(
-          this.browser.dom.window.document,
+          this.browser.currentBrowsingContextWindow.document,
           parameters.using,
           parameters.value,
         );
@@ -243,9 +243,7 @@ class Session {
         reject(new ElementNotInteractable()); // TODO: create new error class
       }
 
-      const activeElement: HTMLElement = this.browser.getActiveElement();
-
-      if (activeElement !== element) element.focus();
+      if (this.browser.getActiveElement() !== element) element.focus();
 
       if (element.tagName.toLowerCase() === 'input') {
         if (text.constructor.name.toLowerCase() !== 'string')
@@ -636,7 +634,7 @@ class Session {
             break;
           case 'xpath':
             elements = locationStrategies.XPathSelector(
-              this.browser.dom.window.document,
+              this.browser.currentBrowsingContextWindow.document,
             );
             break;
           default:
@@ -700,7 +698,9 @@ class Session {
       }
     });
 
-    const { window } = this.browser.dom;
+    // eval is missing from the Window type in typescript
+    // TODO: attempt to fix this in the future by importing @types/jsdom
+    const window = this.browser.currentBrowsingContextWindow as any;
 
     const func = window
       .eval(`(function() {${script}})`)

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -99,7 +99,7 @@ class Session {
         break;
       case COMMANDS.FIND_ELEMENT:
         response = this.elementRetrieval(
-          this.browser.currentBrowsingContextWindow.document,
+          this.browser.getCurrentBrowsingContextWindow().document,
           parameters.using,
           parameters.value,
         )[0];
@@ -107,7 +107,7 @@ class Session {
         break;
       case COMMANDS.FIND_ELEMENTS:
         response = this.elementRetrieval(
-          this.browser.currentBrowsingContextWindow.document,
+          this.browser.getCurrentBrowsingContextWindow().document,
           parameters.using,
           parameters.value,
         );
@@ -634,7 +634,7 @@ class Session {
             break;
           case 'xpath':
             elements = locationStrategies.XPathSelector(
-              this.browser.currentBrowsingContextWindow.document,
+              this.browser.getCurrentBrowsingContextWindow().document,
             );
             break;
           default:
@@ -700,7 +700,7 @@ class Session {
 
     // eval is missing from the Window type in typescript
     // TODO: attempt to fix this in the future by importing @types/jsdom
-    const window = this.browser.currentBrowsingContextWindow as any;
+    const window = this.browser.getCurrentBrowsingContextWindow() as any;
 
     const func = window
       .eval(`(function() {${script}})`)

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -213,7 +213,7 @@ class Session {
       case COMMANDS.GET_ACTIVE_ELEMENT:
         if (!this.browser.dom.window) throw new NoSuchWindow();
         response = this.addElementToKnownElements(
-          this.browser.dom.window.document.activeElement,
+          this.browser.getActiveElement(),
         );
         break;
       default:
@@ -243,7 +243,9 @@ class Session {
         reject(new ElementNotInteractable()); // TODO: create new error class
       }
 
-      if (this.browser.activeElement !== element) element.focus();
+      const activeElement: HTMLElement = this.browser.getActiveElement();
+
+      if (activeElement !== element) element.focus();
 
       if (element.tagName.toLowerCase() === 'input') {
         if (text.constructor.name.toLowerCase() !== 'string')


### PR DESCRIPTION
- replaced generic `this.dom.window` lookups to instead return the active browsing context window.
- prerequisite for #159: multiple Window objects from different browsing contexts will need to be handled, as well as the ability to store which window is "active". Therefore, we can no longer use `this.dom.window` for every case.