### PR TITLE
fix: add missing checks for stale element reference errors

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -336,14 +336,33 @@ class Browser {
   }
 
   /**
-   * @param elementId @type {string} the id of a known element in the known element list
+   * Returns true if the element is not attached to the DOM.
+   * @param element - the HTMLElement to be checked
+   * @returns {boolean}
    */
-  getKnownElement(elementId: string): WebElement {
-    let foundElement = null;
-    this.knownElements.forEach(element => {
+  isStaleElement(element: HTMLElement): boolean {
+    const {
+      document: { body },
+    } = this.currentBrowsingContextWindow;
+    return !body.contains(element);
+  }
+
+  /**
+   * Find and return an known element by id
+   * @param elementId @type {string} the id of a known element in the known element list
+   * @throws {StaleElementReference}
+   * @throws {NoSuchElement}
+   * @returns {WebElement}
+   */
+  public getKnownElement(elementId: string): WebElement {
+    let foundElement: WebElement = null;
+    this.knownElements.forEach((element: WebElement) => {
       if (element[ELEMENT] === elementId) foundElement = element;
     });
     if (!foundElement) throw new PlumaError.NoSuchElement();
+    if (this.isStaleElement(foundElement.element)) {
+      throw new PlumaError.StaleElementReference();
+    }
     return foundElement;
   }
 

--- a/src/Error/StaleElementReference.ts
+++ b/src/Error/StaleElementReference.ts
@@ -1,0 +1,11 @@
+import { NotFoundError } from './NotFoundError';
+
+export class StaleElementReference extends NotFoundError {
+  constructor() {
+    super();
+    this.message =
+      'A command failed because the referenced element is no longer attached to the DOM.';
+    this.name = 'StaleElementReference';
+    this.JSONCodeError = 'stale element reference';
+  }
+}

--- a/src/Error/errors.ts
+++ b/src/Error/errors.ts
@@ -11,6 +11,7 @@ import { UnableToSetCookie } from './UnableToSetCookie';
 import { JavaScriptError } from './JavaScriptError';
 import { ScriptTimeout } from './ScriptTimeout';
 import { NoSuchCookie } from './NoSuchCookie';
+import { StaleElementReference } from './StaleElementReference';
 
 export {
   MethodNotAllowed,
@@ -26,4 +27,5 @@ export {
   JavaScriptError,
   ScriptTimeout,
   NoSuchCookie,
+  StaleElementReference,
 };

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -576,8 +576,6 @@ class Session {
    * attempts to find a [[WebElement]] from a given startNode, selection strategy and selector
    */
   elementRetrieval(startNode, strategy, selector) {
-    // TODO: check if element is connected (shadow-root) https://dom.spec.whatwg.org/#connected
-    // check W3C endpoint spec for details
     const endTime = new Date(new Date().getTime() + this.timeouts.implicit);
     let elements;
     const result = [];

--- a/test/jest/e2e/find-element.test.js
+++ b/test/jest/e2e/find-element.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const nock = require('nock');
+
+const { app } = require('../../../build/app');
+const { createSession } = require('./helpers');
+const { ELEMENT } = require('../../../build/constants/constants');
+
+describe('Find Element', () => {
+  let sessionId;
+
+  beforeAll(async () => {
+    nock(/plumadriver\.com/)
+      .get('/')
+      .reply(
+        200,
+        `<!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <title>Test Page</title>
+          </head>
+          <body>
+            <h1>Test</h1>
+          </body>
+        </html>
+        `,
+      );
+
+    sessionId = await createSession(request, app);
+    await request(app)
+      .post(`/session/${sessionId}/url`)
+      .send({
+        url: 'http://plumadriver.com',
+      });
+  });
+
+  it('throws stale element reference error on removed element', async () => {
+    const {
+      body: {
+        value: { [ELEMENT]: elementId },
+      },
+    } = await request(app)
+      .post(`/session/${sessionId}/element`)
+      .send({ using: 'css selector', value: 'h1' })
+      .expect(200);
+
+    expect(typeof elementId).toBe('string');
+
+    await request(app)
+      .post(`/session/${sessionId}/execute/sync`)
+      .send({
+        script:
+          "const h1 = document.querySelector('h1'); h1.parentNode.removeChild(h1)",
+        args: [],
+      })
+      .expect(200);
+
+    const {
+      body: { value },
+    } = await request(app)
+      .post(`/session/${sessionId}/element/${elementId}/elements`)
+      .send({ using: 'css selector', value: 'foo' })
+      .expect(404);
+
+    expect(value.error).toBe('stale element reference');
+  });
+});


### PR DESCRIPTION
- added `StaleElementReference` error class.
- fixed logic to throw this error in element endpoints whenever an element that is not connected to the DOM is accessed.
- added test for stale element checks

Closes #160.