### PR TITLE
fix: pageLoad default timeout

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -64,7 +64,7 @@ class Session {
     this.secureTLS = true;
     this.timeouts = {
       implicit: 0,
-      pageLoad: 30000,
+      pageLoad: 300000,
       script: 30000,
     };
     this.configureSession(requestBody);

--- a/test/jest/e2e/timeouts.test.js
+++ b/test/jest/e2e/timeouts.test.js
@@ -3,7 +3,7 @@ const { app } = require('../../../build/app');
 const { createSession } = require('./helpers');
 
 describe('Timeouts', () => {
-  it.skip('should respond with proper timeout defaults', async () => {
+  it('should respond with proper timeout defaults', async () => {
     const sessionId = await createSession(request, app);
     const { body } = await request(app).get(`/session/${sessionId}/timeouts`);
 


### PR DESCRIPTION
- Changes default pageLoad value to 300000 as indicated in the spec. (Closes #93)
- Unskipped relevant test.