### PR TITLE
refactor: replace Object hasOwnProperty calls with 'has' package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4031,8 +4031,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -4227,7 +4226,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "express": "^4.17.1",
     "express-winston": "^3.4.0",
     "express_logger": "0.0.4",
+    "has": "^1.0.3",
     "jsdom": "^16.2.1",
     "mime-types": "^2.1.26",
     "minimist": "^1.2.5",

--- a/src/CapabilityValidator/CapabilityValidator.ts
+++ b/src/CapabilityValidator/CapabilityValidator.ts
@@ -1,4 +1,5 @@
 import validator from 'validator';
+import has from 'has';
 import { validate } from '../utils/utils';
 import {
   UnhandledPromptBehaviourValues,
@@ -87,7 +88,7 @@ class CapabilityValidator {
       'noProxy',
       'sslProxy',
       'socksProxy',
-      'socksVersion'
+      'socksVersion',
     ];
 
     let validProxy = true;
@@ -103,10 +104,7 @@ class CapabilityValidator {
             switch (key) {
               case 'proxyType':
                 if (reqProxy[key] === 'pac') {
-                  validProxy = Object.prototype.hasOwnProperty.call(
-                    reqProxy,
-                    'proxyAutoConfigUrl'
-                  );
+                  validProxy = has(reqProxy, 'proxyAutoConfigUrl');
                 } else if (
                   reqProxy[key] !== 'direct' &&
                   reqProxy[key] !== 'autodetect' &&
@@ -132,10 +130,7 @@ class CapabilityValidator {
               case 'socksProxy':
                 validProxy = reqProxy.proxyType === 'manual';
                 validProxy = validProxy
-                  ? Object.prototype.hasOwnProperty.call(
-                      reqProxy,
-                      'socksVersion'
-                    )
+                  ? has(reqProxy, 'socksVersion')
                   : validProxy;
 
                 validProxy = validProxy
@@ -151,7 +146,7 @@ class CapabilityValidator {
                   : validProxy;
                 break;
               case 'noProxy':
-                validProxy = reqProxy[key] instanceof Array
+                validProxy = reqProxy[key] instanceof Array;
                 if (validProxy) {
                   reqProxy[key].forEach(url => {
                     if (validProxy) validProxy = validator.isURL(url);
@@ -173,17 +168,15 @@ class CapabilityValidator {
    * @param key the type of timeout to validate
    * @param value the value of the given timeout
    */
-  validateTimeouts(key, value) :boolean {
+  validateTimeouts(key, value): boolean {
     this.valid = TimeoutValues.guard(key);
-    this.valid = this.valid
-      ? (Number.isInteger(value) && value > 0)
-      : this.valid;
+    this.valid = this.valid ? Number.isInteger(value) && value > 0 : this.valid;
     return this.valid;
   }
 
   /**
-   * Validates plumadriver specific options 
-   * @param options vendor (plumadriver) specific options 
+   * Validates plumadriver specific options
+   * @param options vendor (plumadriver) specific options
    */
   static validatePlumaOptions(options) {
     let validatedOptions = true;
@@ -203,8 +196,8 @@ class CapabilityValidator {
         else valid = false;
 
         if (
-          validTypes.includes(contentType)
-          || contentType.substr(contentType.length - 4) === '+xml'
+          validTypes.includes(contentType) ||
+          contentType.substr(contentType.length - 4) === '+xml'
         ) {
           valid = true;
         } else valid = false;
@@ -221,14 +214,14 @@ class CapabilityValidator {
         return value.constructor === Boolean;
       },
       resources(resources) {
-        return (resources.constructor === String && resources === 'useable');
+        return resources.constructor === String && resources === 'useable';
       },
       rejectPublicSuffixes(value) {
         return value.constructor === Boolean;
       },
     };
 
-    Object.keys(options).forEach((key) => {
+    Object.keys(options).forEach(key => {
       if (!Object.keys(allowedOptions).includes(key)) validatedOptions = false;
       if (validatedOptions) {
         try {

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import { Mutex } from 'async-mutex';
 import { VM } from 'vm2';
 import { JSDOM } from 'jsdom';
+import has from 'has';
 
 import { WebElement } from '../WebElement/WebElement';
 import { COMMANDS, ELEMENT } from '../constants/constants';
@@ -281,10 +282,7 @@ class Session {
           if (!validator.isHexColor(text)) throw new InvalidArgument();
           (element as HTMLInputElement).value = text;
         } else {
-          if (
-            !Object.prototype.hasOwnProperty.call(element, 'value') ||
-            element.getAttribute('readonly')
-          )
+          if (!has(element, 'value') || element.getAttribute('readonly'))
             throw new Error('element not interactable'); // TODO: create error class
           // TODO: add check to see if element is mutable, reject with element not interactable
           (element as HTMLInputElement).value = text;
@@ -363,21 +361,11 @@ class Session {
     );
     // extract browser specific data
     const browserConfig = configuredCapabilities['plm:plumaOptions'];
-    if (
-      Object.prototype.hasOwnProperty.call(
-        configuredCapabilities,
-        'acceptInsecureCerts',
-      )
-    ) {
+    if (has(configuredCapabilities, 'acceptInsecureCerts')) {
       browserConfig.strictSSL = !configuredCapabilities.acceptInsecureCerts;
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(
-        configuredCapabilities,
-        'rejectPublicSuffixes',
-      )
-    ) {
+    if (has(configuredCapabilities, 'rejectPublicSuffixes')) {
       browserConfig.rejectPublicSuffixes =
         configuredCapabilities.rejectPublicSuffixes;
     }
@@ -398,7 +386,7 @@ class Session {
 
     // configure pageLoadStrategy
     if (
-      Object.prototype.hasOwnProperty.call(capabilities, 'pageLoadStrategy') &&
+      has(capabilities, 'pageLoadStrategy') &&
       typeof capabilities.pageLoadStrategy === 'string'
     ) {
       this.pageLoadStrategy = capabilities.pageLoadStrategy;
@@ -406,13 +394,13 @@ class Session {
       capabilities.pageLoadStrategy = 'normal';
     }
 
-    if (Object.prototype.hasOwnProperty.call(capabilities, 'proxy')) {
+    if (has(capabilities, 'proxy')) {
       // TODO: set JSDOM proxy address
     } else {
       capabilities.proxy = {};
     }
 
-    if (Object.prototype.hasOwnProperty.call(capabilities, 'timeouts')) {
+    if (has(capabilities, 'timeouts')) {
       this.setTimeouts(capabilities.timeouts);
     }
     capabilities.timeouts = this.timeouts;
@@ -450,9 +438,7 @@ class Session {
     const requiredCapabilities = {};
     if (capabilities.alwaysMatch !== undefined) {
       defaultCapabilities.forEach(key => {
-        if (
-          Object.prototype.hasOwnProperty.call(capabilities.alwaysMatch, key)
-        ) {
+        if (has(capabilities.alwaysMatch, key)) {
           const validatedCapability = capabilityValidator.validate(
             capabilities.alwaysMatch[key],
             key,
@@ -530,7 +516,7 @@ class Session {
     if (secondary === undefined) return result;
 
     Object.keys(secondary).forEach(property => {
-      if (Object.prototype.hasOwnProperty.call(primary, property)) {
+      if (has(primary, property)) {
         throw new InvalidArgument();
       }
       result[property] = secondary[property];

--- a/src/WebElement/WebElement.ts
+++ b/src/WebElement/WebElement.ts
@@ -1,4 +1,5 @@
 import uuidv1 from 'uuid/v1';
+import has from 'has';
 import { isFocusableAreaElement } from 'jsdom/lib/jsdom/living/helpers/focusing';
 import { implSymbol } from 'jsdom/lib/jsdom/living/generated/utils';
 import { ELEMENT, ElementBooleanAttributeValues } from '../constants/constants';
@@ -211,10 +212,7 @@ class WebElement {
   ): void {
     let isEmpty: boolean;
 
-    if (
-      isInputElement(element) &&
-      Object.prototype.hasOwnProperty.call(element, 'files')
-    ) {
+    if (isInputElement(element) && has(element, 'files')) {
       isEmpty = element.files.length === 0;
     } else {
       isEmpty = element.value === '';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import { Pluma } from '../Types/types';
 import * as PlumaError from '../Error/errors';
 import fs from 'fs';
+import has from 'has';
 import isDisplayedAtom from './isdisplayed-atom.json';
 import { version } from 'pjson';
 
@@ -102,9 +103,7 @@ export const endpoint = {
     let response = null;
     const result = await req.session.process(req.sessionRequest);
     if (result) {
-      response = Object.prototype.hasOwnProperty.call(result, 'value')
-        ? result
-        : { value: result };
+      response = has(result, 'value') ? result : { value: result };
       res.json(response);
     } else {
       res.send(response);


### PR DESCRIPTION
- Uses a stored lookup of `Object.hasOwnProperty.call` (Closes #47).
- Some diffs are from prettier formatting.