### PR TITLE
fix: unhandledPromptBehavior not working in 'ignore' cases

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -31,7 +31,7 @@ class Browser {
     const browserOptions: Pluma.BrowserOptions = {
       runScripts: '',
       strictSSL: true,
-      unhandledPromptBehaviour: 'dismiss and notify',
+      unhandledPromptBehavior: 'dismiss and notify',
       rejectPublicSuffixes: false,
     };
 

--- a/src/Browser/BrowserConfig.ts
+++ b/src/Browser/BrowserConfig.ts
@@ -15,11 +15,11 @@ export class BrowserConfig {
   /** defines whether self-signed or insecure SSL certificates should be trusted */
   strictSSL = true;
 
-  /** defines the type of behaviour when a user prompt is encountered see [W3C unhandledPromptBehaviour](https://w3c.github.io/webdriver/#dfn-unhandled-prompt-behavior) */
-  readonly unhandledPromptBehaviour: Pluma.UnhandledPromptBehaviour = 'dismiss';
+  /** defines the type of behavior when a user prompt is encountered see [W3C unhandledPromptBehavior](https://w3c.github.io/webdriver/#dfn-unhandled-prompt-behavior) */
+  readonly unhandledPromptBehavior: Pluma.unhandledPromptBehavior = 'dismiss';
 
   /** the jsdom [resource loader](https://github.com/jsdom/jsdom#loading-subresources)
-   * allows a more comprehensive customization of jsdom resource-loading behaviour
+   * allows a more comprehensive customization of jsdom resource-loading behavior
    */
   readonly resourceLoader: ResourceLoader;
 
@@ -70,7 +70,7 @@ export class BrowserConfig {
           : true,
     });
 
-    switch (options.unhandledPromptBehaviour) {
+    switch (options.unhandledPromptBehavior) {
       case 'accept':
         this.beforeParse = this.beforeParseFactory(() => true);
         break;
@@ -90,6 +90,7 @@ export class BrowserConfig {
         });
         break;
       case 'ignore':
+        this.beforeParse = window => this.injectAPIs(window);
         break;
       default:
         break;

--- a/src/CapabilityValidator/CapabilityValidator.ts
+++ b/src/CapabilityValidator/CapabilityValidator.ts
@@ -2,7 +2,7 @@ import validator from 'validator';
 import has from 'has';
 import { validate } from '../utils/utils';
 import {
-  UnhandledPromptBehaviourValues,
+  unhandledPromptBehaviorValues,
   PageLoadStrategyValues,
   TimeoutValues,
 } from '../constants/constants';
@@ -46,7 +46,7 @@ class CapabilityValidator {
       case 'unhandledPromptBehavior':
         this.valid = typeof capability === 'string';
         this.valid = this.valid
-          ? UnhandledPromptBehaviourValues.guard(capability)
+          ? unhandledPromptBehaviorValues.guard(capability)
           : this.valid;
         break;
       case 'proxy':

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -49,12 +49,12 @@ class Session {
   browser: Browser;
   /** */
   pageLoadStrategy: Pluma.PageLoadStrategy = 'normal';
-  /** indicated wherher untrusted or self-signed TLS certificates should be trusted for the duration of the webdrive session */
+  /** indicated whether untrusted or self-signed TLS certificates should be trusted for the duration of the webdriver session */
   acceptInsecureCerts: boolean;
-  /** records the timeout duration values used to control the behaviour of script evaluation, navigation and element retrieval */
+  /** records the timeout duration values used to control the behavior of script evaluation, navigation and element retrieval */
   timeouts: Pluma.Timeouts;
   /**
-   * a queue of [[Pluma.Request]] currently awaiting processsing
+   * a queue of [[Pluma.Request]] currently awaiting processing
    *  */
   mutex: Mutex;
   proxy: Record<string, unknown> | null;
@@ -423,7 +423,7 @@ class Session {
       'pageLoadStrategy',
       'proxy',
       'timeouts',
-      'unhandledPromptBehaviour',
+      'unhandledPromptBehavior',
       'plm:plumaOptions',
     ];
 

--- a/src/SessionManager/SessionManager.ts
+++ b/src/SessionManager/SessionManager.ts
@@ -48,8 +48,8 @@ class SessionManager {
           'plm:plumaOptions': {
             runScripts: session.browser.browserConfig.runScripts,
           },
-          unhandledPromptBehaviour:
-            session.browser.browserConfig.unhandledPromptBehaviour,
+          unhandledPromptBehavior:
+            session.browser.browserConfig.unhandledPromptBehavior,
           proxy: session.proxy ? session.proxy : {},
           timeouts: session.timeouts,
         },

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -1,16 +1,16 @@
 import {
   ElementBooleanAttributeValues,
-  UnhandledPromptBehaviourValues,
+  unhandledPromptBehaviorValues,
   RunScriptsValues,
   PageLoadStrategyValues,
 } from '../constants/constants';
 
 /**
- * contains interfaces paticular to plumadriver
+ * contains interfaces particular to plumadriver
  */
 export namespace Pluma {
   type RunScripts = typeof RunScriptsValues.type;
-  type UnhandledPromptBehaviour = typeof UnhandledPromptBehaviourValues.type;
+  type unhandledPromptBehavior = typeof unhandledPromptBehaviorValues.type;
   type BeforeParse = (window) => void;
   type UserPrompt = (message?: string) => boolean;
   type ElementBooleanAttribute = typeof ElementBooleanAttributeValues.type;
@@ -22,7 +22,7 @@ export namespace Pluma {
   interface BrowserOptions {
     runScripts: RunScripts;
     strictSSL: boolean;
-    unhandledPromptBehaviour: UnhandledPromptBehaviour;
+    unhandledPromptBehavior: unhandledPromptBehavior;
     rejectPublicSuffixes: boolean;
   }
 
@@ -53,7 +53,7 @@ export namespace Pluma {
   }
 
   /**
-   * The timeouts object which records the timeout duration values used to control the behaviour of script evaluation
+   * The timeouts object which records the timeout duration values used to control the behavior of script evaluation
    * navigation and element retrieval
    */
   interface Timeouts {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -44,8 +44,8 @@ export const ElementBooleanAttributeValues = StringUnion(
 /** W3C webdriver valid session [timeout types](https://w3c.github.io/webdriver/#timeouts)*/
 export const TimeoutValues = StringUnion('script', 'pageLoad', 'implicit');
 
-/** W3C webdriver valid [unhandled prompt behaviour](https://w3c.github.io/webdriver/#dfn-unhandled-prompt-behavior) values */
-export const UnhandledPromptBehaviourValues = StringUnion(
+/** W3C webdriver valid [unhandled prompt behavior](https://w3c.github.io/webdriver/#dfn-unhandled-prompt-behavior) values */
+export const unhandledPromptBehaviorValues = StringUnion(
   'accept',
   'dismiss',
   'dismiss and notify',

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -39,7 +39,7 @@ export const isBrowserOptions = (obj: any): obj is Pluma.BrowserOptions => {
   if (
     obj.runScripts === undefined ||
     obj.strictSSL === undefined ||
-    obj.unhandledPromptBehaviour === undefined ||
+    obj.unhandledPromptBehavior === undefined ||
     obj.rejectPublicSuffixes === undefined
   )
     return false;

--- a/test/jest/e2e/session.test.js
+++ b/test/jest/e2e/session.test.js
@@ -12,7 +12,7 @@ describe('Session', () => {
     return body;
   };
 
-  it.skip('creates a session with alwaysMatch capabilities', async () => {
+  it('creates a session with alwaysMatch capabilities', async () => {
     const requestBody = {
       capabilities: {
         alwaysMatch: {

--- a/test/jest/e2e/session.test.js
+++ b/test/jest/e2e/session.test.js
@@ -38,7 +38,7 @@ describe('Session', () => {
           browserVersion: expect.stringMatching(/^v\d+(\.\d+)*$/),
           pageLoadStrategy: 'normal',
           platformName: expect.any(String),
-          unhandledPromptBehaviour: 'ignore',
+          unhandledPromptBehavior: 'ignore',
           timeouts: {
             implicit: 100,
             pageLoad: 200,


### PR DESCRIPTION
- Renamed `behaviour` to `behavior` to match client requests according to spec.
- Unskipped `alwaysMatch` session test.
- Added logic to handle `ignore` cases. (Closes #111)