### PR TITLE
fix: set timeout endpoint not accepting zero values

### DIFF
--- a/src/CapabilityValidator/CapabilityValidator.ts
+++ b/src/CapabilityValidator/CapabilityValidator.ts
@@ -169,8 +169,11 @@ class CapabilityValidator {
    * @param value the value of the given timeout
    */
   validateTimeouts(key, value): boolean {
-    this.valid = TimeoutValues.guard(key);
-    this.valid = this.valid ? Number.isInteger(value) && value > 0 : this.valid;
+    this.valid =
+      TimeoutValues.guard(key) && Number.isInteger(value) && value >= 0
+        ? true
+        : false;
+
     return this.valid;
   }
 

--- a/src/routes/timeouts.ts
+++ b/src/routes/timeouts.ts
@@ -1,18 +1,16 @@
 import express from 'express';
-import { InvalidArgument } from '../Error/errors';
-import { COMMANDS } from '../constants/constants';
 
 const timeouts = express.Router();
 
-timeouts.get('/', (req, res, next) => {
+timeouts.get('/', (req, res) => {
   const response = { value: req.session.getTimeouts() };
   res.json(response);
 });
 
 // set timeouts
-timeouts.post('/', (req, res, next) => {
+timeouts.post('/', (req, res) => {
   req.session.setTimeouts(req.body);
-  res.send(null);
+  res.send({ value: null });
 });
 
 export default timeouts;

--- a/test/jest/e2e/timeouts.test.js
+++ b/test/jest/e2e/timeouts.test.js
@@ -16,7 +16,7 @@ describe('Timeouts', () => {
     });
   });
 
-  it.skip('should set requested timeouts', async () => {
+  it('should set requested timeouts', async () => {
     const sessionId = await createSession(request, app);
     const requestedTimeouts = {
       script: 0,


### PR DESCRIPTION
- fix validation logic for timeouts (Closes #92).
- fix endpoint return value in express.
- unskip timeout test.