### PR TITLE
refactor: replace constructor name checks

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -255,8 +255,7 @@ class Session {
       if (this.browser.getActiveElement() !== element) element.focus();
 
       if (element.tagName.toLowerCase() === 'input') {
-        if (text.constructor.name.toLowerCase() !== 'string')
-          reject(new InvalidArgument());
+        if (typeof text === 'string') reject(new InvalidArgument());
         // file input
         if (element.getAttribute('type') === 'file') {
           files = text.split('\n');
@@ -458,7 +457,7 @@ class Session {
     if (allMatchedCapabilities === undefined) {
       allMatchedCapabilities = [{}];
     } else if (
-      allMatchedCapabilities.constructor.name.toLowerCase() !== 'array' ||
+      !Array.isArray(allMatchedCapabilities) ||
       allMatchedCapabilities.length === 0
     ) {
       throw new InvalidArgument();

--- a/test/jest/capability-validator.test.js
+++ b/test/jest/capability-validator.test.js
@@ -44,7 +44,7 @@ describe('Testing CapabilityValidator class', () => {
     capabilities.forEach(capability => {
       it(`${capability} should only accept string values`, () => {
         runTestAgainstTestData(data => {
-          if (data.constructor.name.toLowerCase() === 'string')
+          if (typeof data === 'string')
             expect(capabilityValidator.validate(data, capability)).toBe(true);
           else
             expect(capabilityValidator.validate(data, capability)).toBe(false);
@@ -56,7 +56,7 @@ describe('Testing CapabilityValidator class', () => {
   describe('Testing acceptInsecureCerts validation', () => {
     it('should only accept boolean values', () => {
       runTestAgainstTestData(data => {
-        if (data.constructor.name.toLowerCase() === 'boolean')
+        if (typeof data === 'boolean')
           expect(
             capabilityValidator.validate(data, 'acceptInsecureCerts'),
           ).toBe(true);


### PR DESCRIPTION
- Replaced type checking performed with the constructor name (Closes #34).