### PR TITLE
fix: return { value: null } in cases where response was null

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -228,7 +228,7 @@ class Session {
       default:
         break;
     }
-    return response;
+    return response || { value: null };
   }
 
   /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -99,15 +99,10 @@ export const endpoint = {
         release();
       });
   },
-  async defaultSessionEndpointLogic(req, res, additionalLogic = null) {
-    let response = null;
+
+  async defaultSessionEndpointLogic(req, res) {
     const result = await req.session.process(req.sessionRequest);
-    if (result) {
-      response = has(result, 'value') ? result : { value: result };
-      res.json(response);
-    } else {
-      res.send(response);
-    }
+    res.json(has(result, 'value') ? result : { value: result });
   },
 };
 

--- a/test/jest/e2e/navigation.test.js
+++ b/test/jest/e2e/navigation.test.js
@@ -23,8 +23,8 @@ describe('Navigation', () => {
     sessionId = await createSession(request, app);
   });
 
-  it.skip('navigates to a page and responds with null', async () => {
-    const url = 'http://plumadriver.com';
+  it('navigates to a page and responds with null', async () => {
+    const url = 'http://plumadriver.com/';
     const { body } = await request(app)
       .post(`/session/${sessionId}/url`)
       .send({


### PR DESCRIPTION
- Removes `null` responses, and ensures all JSON responses have a `value` property (Closes #91).
- Unskips { value: null } test. 