### PR TITLE
fix: get all cookies endpoint returning unassociated cookies

### DIFF
--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -140,14 +140,14 @@ class Session {
       case COMMANDS.GET_TIMEOUTS:
         break;
       case COMMANDS.GET_ALL_COOKIES:
-        response = this.browser.getCookies();
+        response = await this.browser.getAllCookies();
         break;
       case COMMANDS.ADD_COOKIE:
         response = this.browser.addCookie(parameters.cookie);
         break;
       case COMMANDS.GET_NAMED_COOKIE:
         if (!this.browser.dom.window) throw new NoSuchWindow();
-        const retrievedCookie = this.browser.getNamedCookie(
+        const retrievedCookie = await this.browser.getNamedCookie(
           urlVariables.cookieName,
         );
         response = { value: retrievedCookie };

--- a/test/jest/e2e/cookies.test.js
+++ b/test/jest/e2e/cookies.test.js
@@ -274,8 +274,39 @@ describe('Cookies', () => {
       .expect(200);
 
     // get all cookies
-    expect((await getNamedCookie('')).map(({ name }) => name)).toEqual(
-      expect.arrayContaining(['notAssociated', 'alsoNotAssociated']),
+    expect((await getNamedCookie('')).map(({ name }) => name)).toStrictEqual(
+      [],
     );
+  });
+
+  it('gets all associated cookies', async () => {
+    await addCookie({
+      name: 'notAssociated',
+      value: 'true',
+      domain: '.anotherwebsite.com',
+      path: '/',
+    });
+
+    await request(app)
+      .post(`/session/${sessionId}/url`)
+      .send({
+        url: 'http://plumadriver.com/',
+      })
+      .expect(200);
+
+    const plumadriverCookie = {
+      name: 'associated',
+      value: 'true',
+      domain: 'plumadriver.com',
+      path: '/',
+    };
+
+    await addCookie(plumadriverCookie);
+
+    const {
+      body: { value: cookies },
+    } = await request(app).get(`/session/${sessionId}/cookie`);
+
+    expect(cookies).toStrictEqual([plumadriverCookie]);
   });
 });


### PR DESCRIPTION
- Fixed async cookie operations not being handled properly.
- Refactored naming of cookie functions for better clarity.
- Added test for associated cookie retrieval.

Closes #87.