### PR TITLE
style: fix missing types and return values in typescript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ pluma-logs/
 /test/
 /docs/
 /src/jsdom_extensions/
+/scripts/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,10 @@
     "sourceType": "module"
   },
   "rules": {
-    "@typescript-eslint/explicit-function-return-type": "off"
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_" }
+    ]
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:zip": "run-s build:all build:script",
     "generate-docs": "./node_modules/.bin/typedoc --out docs ./src/ --options ./typedoc.json &>/dev/null",
     "commit": "git cz",
-    "lint": "eslint .",
+    "lint": "eslint . --ext .js,.ts",
     "lint:fix": "eslint --fix ."
   },
   "bin": "bin.js",

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -24,12 +24,12 @@ class Browser {
   dom: JSDOM;
 
   /** the Window of the current browsing context */
-  private currentBrowsingContextWindow: Window;
+  private currentBrowsingContextWindow: Pluma.DOMWindow;
 
   /** accepts a capabilities object with jsdom and plumadriver specific options */
   constructor(capabilities: object) {
     const browserOptions: Pluma.BrowserOptions = {
-      runScripts: '',
+      runScripts: 'dangerously',
       strictSSL: true,
       unhandledPromptBehavior: 'dismiss and notify',
       rejectPublicSuffixes: false,
@@ -49,9 +49,9 @@ class Browser {
    */
   async configureBrowser(
     config: BrowserConfig,
-    url: URL | null,
+    url: string,
     pathType = 'url',
-  ) {
+  ): Promise<void> {
     let dom;
 
     if (url !== null) {
@@ -75,7 +75,7 @@ class Browser {
 
       /*  promise resolves after load event has fired. Allows onload events to execute
       before the DOM object can be manipulated  */
-      const loadEvent = () =>
+      const loadEvent = (): Promise<JSDOM> =>
         new Promise(resolve => {
           dom.window.addEventListener('load', () => {
             resolve(dom);
@@ -104,7 +104,7 @@ class Browser {
   /**
    * handles errors thrown by the navigation function
    */
-  private handleNavigationError(error, config) {
+  private handleNavigationError(error, config): void {
     // the jsdom instance will otherwise crash on a 401
     if (error.statusCode === 401) {
       this.dom = new JSDOM(' ', {
@@ -123,7 +123,7 @@ class Browser {
    * accepts a url and pathType @type {String} from which to instantiate the
    * jsdom object
    */
-  async navigate(path: URL, pathType) {
+  async navigate(path: string, pathType): Promise<boolean> {
     if (path) {
       try {
         await this.configureBrowser(this.browserConfig, path, pathType);
@@ -154,7 +154,7 @@ class Browser {
    * Get the Window object associated with the current browsing context.
    * @returns {Window}
    */
-  public getCurrentBrowsingContextWindow(): Window {
+  public getCurrentBrowsingContextWindow(): Pluma.DOMWindow {
     return this.currentBrowsingContextWindow;
   }
 
@@ -162,7 +162,7 @@ class Browser {
    * Set the Window for the current browsing context.
    * @param {Window} window - the Window object
    */
-  public setCurrentBrowsingContextWindow(window: Window) {
+  public setCurrentBrowsingContextWindow(window: Pluma.DOMWindow): void {
     this.currentBrowsingContextWindow = window;
   }
 
@@ -428,7 +428,7 @@ class Browser {
   /**
    * terminates all scripts and timers initiated in jsdom vm
    */
-  close() {
+  close(): void {
     this.dom.window.close();
   }
 }

--- a/src/Browser/BrowserConfig.ts
+++ b/src/Browser/BrowserConfig.ts
@@ -10,7 +10,7 @@ import * as Utils from '../utils/utils';
  */
 export class BrowserConfig {
   /** defines the context under which scripts can run, if at all */
-  runScripts: Pluma.RunScripts | null;
+  runScripts: Pluma.RunScripts;
 
   /** defines whether self-signed or insecure SSL certificates should be trusted */
   strictSSL = true;
@@ -90,7 +90,7 @@ export class BrowserConfig {
         });
         break;
       case 'ignore':
-        this.beforeParse = window => this.injectAPIs(window);
+        this.beforeParse = (window): void => this.injectAPIs(window);
         break;
       default:
         break;
@@ -101,7 +101,7 @@ export class BrowserConfig {
    * Accepts a [[Pluma.UserPrompt]] object
    * to define the window.alert, window.prompt and window.confirm methods */
   private beforeParseFactory = (func: Pluma.UserPrompt) => {
-    return window => {
+    return (window): void => {
       ['confirm', 'alert', 'prompt'].forEach(method => {
         window[method] = func;
       });
@@ -114,14 +114,14 @@ export class BrowserConfig {
    * Injects missing APIs into jsdom for better compatibility.
    */
   private injectAPIs(window): void {
-    window.HTMLElement.prototype.scrollIntoView = () => undefined;
+    window.HTMLElement.prototype.scrollIntoView = (): void => undefined;
 
     window.performance.timing = {
       navigationStart: window.performance.timeOrigin,
     };
 
     window.SVGRectElement = Object.create(window.SVGElement);
-    window.SVGRectElement.prototype.getBBox = () => ({
+    window.SVGRectElement.prototype.getBBox = (): Pluma.SVGRectElement => ({
       x: 1,
       y: 1,
       width: 1,

--- a/src/Browser/CookieValidator.ts
+++ b/src/Browser/CookieValidator.ts
@@ -10,15 +10,15 @@ export class CookieValidator {
     return isString(value);
   }
 
-  static isValidSecure(secure: boolean) {
+  static isValidSecure(secure: boolean): boolean {
     return secure === undefined || isBoolean(secure);
   }
 
-  static isValidHttpOnly(httpOnly: boolean) {
+  static isValidHttpOnly(httpOnly: boolean): boolean {
     return httpOnly === undefined || isBoolean(httpOnly);
   }
 
-  static isValidExpiry(expiry: number) {
+  static isValidExpiry(expiry: number): boolean {
     return (
       expiry === undefined ||
       (Number.isInteger(expiry) &&

--- a/src/CapabilityValidator/CapabilityValidator.ts
+++ b/src/CapabilityValidator/CapabilityValidator.ts
@@ -26,7 +26,7 @@ class CapabilityValidator {
    * @param capability the capability object
    * @param capabilityName the name of the capability to be validated
    */
-  validate(capability, capabilityName) {
+  validate(capability, capabilityName): boolean {
     switch (capabilityName) {
       case 'browserName':
       case 'browserVersion':
@@ -79,7 +79,7 @@ class CapabilityValidator {
   /**
    * validates proxy for session
    */
-  static validateProxy(reqProxy) {
+  static validateProxy(reqProxy): boolean {
     const proxyProperties = [
       'proxyType',
       'proxyAutoConfigUrl',
@@ -181,17 +181,17 @@ class CapabilityValidator {
    * Validates plumadriver specific options
    * @param options vendor (plumadriver) specific options
    */
-  static validatePlumaOptions(options) {
+  static validatePlumaOptions(options): boolean {
     let validatedOptions = true;
 
     const allowedOptions = {
-      url(url) {
+      url(url): boolean {
         return validator.isURL(url);
       },
-      referrer(referrer) {
+      referrer(referrer): boolean {
         return validator.isURL(referrer);
       },
-      contentType(contentType) {
+      contentType(contentType): boolean {
         let valid;
         const validTypes = ['text/html', 'application/xml'];
 
@@ -207,19 +207,19 @@ class CapabilityValidator {
 
         return valid;
       },
-      includeNodeLocations(value) {
+      includeNodeLocations(value): boolean {
         return value.constructor === Boolean;
       },
-      storageQuota(quota) {
+      storageQuota(quota): boolean {
         return Number.isInteger(quota);
       },
-      runScripts(value) {
+      runScripts(value): boolean {
         return value.constructor === Boolean;
       },
-      resources(resources) {
+      resources(resources): boolean {
         return resources.constructor === String && resources === 'useable';
       },
-      rejectPublicSuffixes(value) {
+      rejectPublicSuffixes(value): boolean {
         return value.constructor === Boolean;
       },
     };

--- a/src/SessionManager/SessionManager.ts
+++ b/src/SessionManager/SessionManager.ts
@@ -10,7 +10,7 @@ import { getVersion } from '../utils/utils';
 class SessionManager {
   /** the Active Plumadriver sessions */
   sessions: Array<Session>;
-  /** plumadriver's [readiness state](https://w3c.github.io/webdriver/#nodes) */
+  /** Plumadriver's [readiness state](https://w3c.github.io/webdriver/#nodes) */
   readinessState: Pluma.ReadinessState;
   constructor() {
     this.sessions = [];
@@ -32,9 +32,10 @@ class SessionManager {
    * Creates a new @type {Session}
    * from a user defined session configuration object
    */
-  createSession(requestBody) {
+  createSession(requestBody): Pluma.SessionConfig {
     const session = new Session(requestBody);
     this.sessions.push(session);
+
     const sessionConfig = {
       value: {
         sessionId: session.id,
@@ -61,7 +62,7 @@ class SessionManager {
   /**
    * find a session from a user specified uuid
    */
-  findSession(sessionId: string) {
+  findSession(sessionId: string): Session {
     const foundSession = this.sessions.find(
       session => session.id === sessionId,
     );
@@ -75,7 +76,10 @@ class SessionManager {
   /**
    * deletes a session from a user specified uuid
    */
-  async deleteSession(currentSession: Session, request: Pluma.Request) {
+  async deleteSession(
+    currentSession: Session,
+    request: Pluma.Request,
+  ): Promise<void> {
     const index = this.sessions
       .map(session => session.id)
       .indexOf(currentSession.id);
@@ -86,7 +90,7 @@ class SessionManager {
   /**
    * updates and then returns the drivers readiness state
    */
-  getReadinessState() {
+  getReadinessState(): Pluma.ReadinessState {
     this.readinessState.status = this.sessions.length;
     return this.readinessState;
   }

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -45,9 +45,23 @@ export namespace Pluma {
    */
   interface Request {
     /** the http url variables */
-    urlVariables: any;
+    urlVariables: {
+      elementId?: string;
+      attributeName?: string;
+      cookieName?: string;
+    };
     /** the parameters passed inside the body of the http request */
-    parameters: any;
+    parameters: {
+      id?: string;
+      args?: unknown[];
+      script?: string;
+      text?: string;
+      cookieName?: string;
+      value?: string;
+      cookie?: Pluma.Cookie;
+      using?: string;
+      url?: string;
+    };
     /** the specific webdriver command to be executed */
     command: string;
   }
@@ -83,6 +97,52 @@ export namespace Pluma {
       error: string;
       message: string;
       stacktrace: string;
+    };
+  }
+
+  interface SVGRectElement {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
+  interface PlumaOptions {
+    runScripts: RunScripts;
+    unhandledPromptBehavior?: unhandledPromptBehavior;
+    rejectPublicSuffixes?: boolean;
+    strictSSL?: boolean;
+  }
+
+  interface Capabilities {
+    pageLoadStrategy?: PageLoadStrategy;
+    proxy?: string | {};
+    timeouts?: Timeouts;
+    rejectPublicSuffixes?: boolean;
+    unhandledPromptBehavior?: unhandledPromptBehavior;
+    acceptInsecureCerts: boolean;
+    browserName: string;
+    browserVersion: string;
+    platformName: NodeJS.Platform;
+    setWindowRect: boolean;
+    'plm:plumaOptions'?: PlumaOptions;
+  }
+
+  interface SerializedWebElement {
+    'element-6066-11e4-a52e-4f735466cecf': string;
+  }
+
+  interface DOMWindow extends Window {
+    eval?: (script: string) => (...args: unknown[]) => unknown;
+    NodeList?: [];
+    HTMLCollection?: [];
+    HTMLElement?: [];
+  }
+
+  interface SessionConfig {
+    value: {
+      sessionId: string;
+      capabilities: Capabilities;
     };
   }
 }

--- a/src/WebElement/WebElement.ts
+++ b/src/WebElement/WebElement.ts
@@ -12,6 +12,7 @@ import {
 
 // TODO: find a more efficient way to import this
 import { JSDOM } from 'jsdom';
+import { Pluma } from '../Types/types';
 const { MouseEvent, getComputedStyle } = new JSDOM().window;
 
 class WebElement {
@@ -249,7 +250,7 @@ class WebElement {
    * returns the JSON representation of the WebElement
    * @returns {Object}
    */
-  public serialize() {
+  public serialize(): Pluma.SerializedWebElement {
     return { [ELEMENT]: this[ELEMENT] };
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,8 +28,7 @@ app.use('/', router);
 app.use(errorLogger);
 
 // error handler
-// eslint-disable-next-line no-unused-vars
-app.use((err, req, res, next) => {
+app.use((err, req, res, _next) => {
   const errorResponse: Pluma.ErrorResponse = {
     value: {
       error: err.JSONCodeError,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -54,7 +54,7 @@ export const unhandledPromptBehaviorValues = StringUnion(
 );
 
 /** JSDOM specific option defining which scripts will execute. More information [here](https://github.com/jsdom/jsdom#executing-scripts) */
-export const RunScriptsValues = StringUnion('dangerously', 'outside-only', '');
+export const RunScriptsValues = StringUnion('dangerously', 'outside-only');
 
 /** W3C specific user agent [page loading strategies](https://w3c.github.io/webdriver/#dfn-page-loading-strategy) */
 export const PageLoadStrategyValues = StringUnion('none', 'eager', 'normal');

--- a/src/routes/elements.ts
+++ b/src/routes/elements.ts
@@ -47,7 +47,7 @@ element.post(
 
 // get element attribute name
 // this endpoint has not been tested as selenium calls execute script instead. Neded to test
-element.get('/attribute/:name', (req, res, next) => {
+element.get('/attribute/:name', (req, _res, _next) => {
   req.sessionRequest.urlVariables.attributeName = req.params.name;
   return sessionEndpointExceptionHandler(
     defaultSessionEndpointLogic,


### PR DESCRIPTION
- Adds missing return types from functions.
- Adds missing interfaces and types for many variables and objects.
- Fixes linter script not working properly in `npm test`.

Progress toward #32.