### PR TITLE
chore: disable CircleCI windows build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,5 @@ jobs:
 workflows:
   build:
     jobs:
-    - build-windows
+    # - build-windows
     - build-linux


### PR DESCRIPTION
The `CircleCI` windows build fails when all the weekly credits have been used. 
To avoid this problem, this PR disables the windows build.