### PR TITLE
refactor: enable some strict options, add type for jsdom/express

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,10 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "argsIgnorePattern": "^_" }
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+      { "ts-expect-error": "allow-with-description" }
     ]
   },
   "overrides": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1707,11 +1707,30 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -1724,6 +1743,29 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
+      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
+      "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -1775,6 +1817,12 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1810,6 +1858,28 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
       "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
       "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
+      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1811,6 +1811,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jsdom": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.4.tgz",
+      "integrity": "sha512-RssgLa5ptjVKRkHho/Ex0+DJWkVsYuV8oh2PSG3gKxFp8n/VNyB7kOrZGQkk2zgPlcBkIKOItUc/T5BXit9uhg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -1853,6 +1864,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
@@ -1885,6 +1902,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "@types/express": "^4.17.8",
+    "@types/jsdom": "^16.2.4",
     "adm-zip": "^0.4.14",
     "commitlint": "^11.0.0",
     "cz-conventional-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
+    "@types/express": "^4.17.8",
     "adm-zip": "^0.4.14",
     "commitlint": "^11.0.0",
     "cz-conventional-changelog": "^3.1.0",

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -96,6 +96,7 @@ class Browser {
     const { window } = this.dom;
 
     // webdriver-active property (W3C)
+    // @ts-expect-error: force setting readonly property
     window.navigator.webdriver = true;
 
     this.setCurrentBrowsingContextWindow(window);
@@ -259,7 +260,7 @@ class Browser {
       }),
       err => {
         if (err) {
-          throw new PlumaError.UnableToSetCookie(err);
+          throw new PlumaError.UnableToSetCookie(err && err.message);
         }
       },
     );
@@ -275,8 +276,8 @@ class Browser {
           reject(err);
         }
 
-        const cookies: Cookie[] = serializedJar.cookies
-          .map((cookie: Pluma.Cookie) => {
+        const cookies: Pluma.Cookie[] = serializedJar.cookies
+          .map(cookie => {
             const currentCookie: Pluma.Cookie = { name: '', value: '' };
             Object.keys(cookie).forEach(key => {
               // renames 'key' property to 'name' for W3C compliance and selenium functionality
@@ -311,7 +312,7 @@ class Browser {
    * returns the cookie in the cookie jar matching the requested name
    */
   public async getNamedCookie(requestedName: string): Promise<Pluma.Cookie> {
-    const allCookies: Cookie[] = await this.getAllCookies();
+    const allCookies = await this.getAllCookies();
     const requestedCookie = allCookies.find(
       (cookie: Pluma.Cookie): boolean =>
         cookie.name === requestedName && this.isAssociatedCookie(cookie),

--- a/src/Browser/BrowserConfig.ts
+++ b/src/Browser/BrowserConfig.ts
@@ -1,4 +1,4 @@
-import { ResourceLoader } from 'jsdom';
+import { ResourceLoader, BaseOptions } from 'jsdom';
 import { Pluma } from '../Types/types';
 import { CookieJar, MemoryCookieStore } from 'tough-cookie';
 import { InvalidArgument } from '../Error/errors';
@@ -10,7 +10,7 @@ import * as Utils from '../utils/utils';
  */
 export class BrowserConfig {
   /** defines the context under which scripts can run, if at all */
-  runScripts: Pluma.RunScripts;
+  runScripts: BaseOptions['runScripts'];
 
   /** defines whether self-signed or insecure SSL certificates should be trusted */
   strictSSL = true;

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -3,7 +3,7 @@ import validator from 'validator';
 import os from 'os';
 import { Mutex } from 'async-mutex';
 import { VM } from 'vm2';
-import { JSDOM } from 'jsdom';
+import { DOMWindow, JSDOM } from 'jsdom';
 import has from 'has';
 
 import { WebElement } from '../WebElement/WebElement';
@@ -705,7 +705,7 @@ class Session {
 
     const window = this.browser.getCurrentBrowsingContextWindow();
 
-    const func = window
+    const func = (window as DOMWindow)
       .eval(`(function() {${script}})`)
       .bind(null, ...argumentList);
 

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -5,6 +5,10 @@ import {
   PageLoadStrategyValues,
 } from '../constants/constants';
 
+// TODO: probably update eslint to avoid the disabled rule below
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { Session } from '../Session/Session';
+
 /**
  * contains interfaces particular to plumadriver
  */
@@ -144,5 +148,15 @@ export namespace Pluma {
       sessionId: string;
       capabilities: Capabilities;
     };
+  }
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      sessionId: string;
+      session: Session;
+      sessionRequest: Pluma.Request;
+    }
   }
 }

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -1,7 +1,8 @@
+import { BaseOptions, DOMWindow as JSDOMDOMWindow } from 'jsdom';
+import { Store } from 'tough-cookie';
 import {
   ElementBooleanAttributeValues,
   unhandledPromptBehaviorValues,
-  RunScriptsValues,
   PageLoadStrategyValues,
 } from '../constants/constants';
 
@@ -13,7 +14,6 @@ import { Session } from '../Session/Session';
  * contains interfaces particular to plumadriver
  */
 export namespace Pluma {
-  type RunScripts = typeof RunScriptsValues.type;
   type unhandledPromptBehavior = typeof unhandledPromptBehaviorValues.type;
   type BeforeParse = (window) => void;
   type UserPrompt = (message?: string) => boolean;
@@ -24,7 +24,7 @@ export namespace Pluma {
    * Client defined options for jsdom
    */
   interface BrowserOptions {
-    runScripts: RunScripts;
+    runScripts: BaseOptions['runScripts'];
     strictSSL: boolean;
     unhandledPromptBehavior: unhandledPromptBehavior;
     rejectPublicSuffixes: boolean;
@@ -112,7 +112,7 @@ export namespace Pluma {
   }
 
   interface PlumaOptions {
-    runScripts: RunScripts;
+    runScripts: BaseOptions['runScripts'];
     unhandledPromptBehavior?: unhandledPromptBehavior;
     rejectPublicSuffixes?: boolean;
     strictSSL?: boolean;
@@ -136,12 +136,7 @@ export namespace Pluma {
     'element-6066-11e4-a52e-4f735466cecf': string;
   }
 
-  interface DOMWindow extends Window {
-    eval?: (script: string) => (...args: unknown[]) => unknown;
-    NodeList?: [];
-    HTMLCollection?: [];
-    HTMLElement?: [];
-  }
+  type DOMWindow = Window | JSDOMDOMWindow;
 
   interface SessionConfig {
     value: {
@@ -153,10 +148,23 @@ export namespace Pluma {
 
 declare global {
   namespace Express {
+    /**
+     * Additional properties of the request object
+     */
     interface Request {
-      sessionId: string;
-      session: Session;
-      sessionRequest: Pluma.Request;
+      sessionId?: string;
+      session?: Session;
+      sessionRequest?: Pluma.Request;
     }
+  }
+
+  interface MouseEventInit {
+    which?: number;
+  }
+}
+
+declare module 'jsdom' {
+  interface CookieJar {
+    store: Store;
   }
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -53,9 +53,6 @@ export const unhandledPromptBehaviorValues = StringUnion(
   'ignore',
 );
 
-/** JSDOM specific option defining which scripts will execute. More information [here](https://github.com/jsdom/jsdom#executing-scripts) */
-export const RunScriptsValues = StringUnion('dangerously', 'outside-only');
-
 /** W3C specific user agent [page loading strategies](https://w3c.github.io/webdriver/#dfn-page-loading-strategy) */
 export const PageLoadStrategyValues = StringUnion('none', 'eager', 'normal');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "watch": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "noImplicitThis": true
   },
   "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "noImplicitThis": true
+    "noImplicitThis": true,
+    "strictBindCallApply": true
   },
   "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "moduleResolution": "node",
     "noImplicitThis": true,
     "strictBindCallApply": true,
-    "strictFunctionTypes": true
+    "strictFunctionTypes": true,
+    "alwaysStrict": true
   },
   "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "noImplicitThis": true,
-    "strictBindCallApply": true
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Solve subtasks in #32:

- [x] `noImplicitThis` @pynnl 
- [x] `strictBindCallApply` @pynnl 
- [x] `strictFunctionTypes` @pynnl 
- [x] `alwaysStrict` @pynnl 
- [x] add type for `jsdom` and `express`, and remove redundancy @pynnl 
