### PR TITLE
refactor: enable strictNullChecks

### DIFF
--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -124,7 +124,7 @@ class Browser {
    * accepts a url and pathType @type {String} from which to instantiate the
    * jsdom object
    */
-  async navigate(path: string, pathType): Promise<boolean> {
+  async navigate(path?: string, pathType?): Promise<boolean> {
     if (path) {
       try {
         await this.configureBrowser(this.browserConfig, path, pathType);
@@ -415,7 +415,7 @@ class Browser {
    * @throws {NoSuchElement}
    * @returns {WebElement}
    */
-  public getKnownElement(elementId: string): WebElement {
+  public getKnownElement(elementId?: string): WebElement {
     let foundElement: WebElement | null = null;
     this.knownElements.forEach((element: WebElement) => {
       if (element[ELEMENT] === elementId) foundElement = element;

--- a/src/Browser/CookieValidator.ts
+++ b/src/Browser/CookieValidator.ts
@@ -10,15 +10,15 @@ export class CookieValidator {
     return isString(value);
   }
 
-  static isValidSecure(secure: boolean): boolean {
+  static isValidSecure(secure?: boolean): boolean {
     return secure === undefined || isBoolean(secure);
   }
 
-  static isValidHttpOnly(httpOnly: boolean): boolean {
+  static isValidHttpOnly(httpOnly?: boolean): boolean {
     return httpOnly === undefined || isBoolean(httpOnly);
   }
 
-  static isValidExpiry(expiry: number): boolean {
+  static isValidExpiry(expiry?: number): boolean {
     return (
       expiry === undefined ||
       (Number.isInteger(expiry) &&
@@ -35,9 +35,9 @@ export class CookieValidator {
     }
 
     return (
-      this.isValidHttpOnly(httpOnly as boolean) &&
-      this.isValidSecure(secure as boolean) &&
-      this.isValidExpiry(expiry as number)
+      this.isValidHttpOnly(httpOnly) &&
+      this.isValidSecure(secure) &&
+      this.isValidExpiry(expiry)
     );
   }
 }

--- a/src/Browser/CookieValidator.ts
+++ b/src/Browser/CookieValidator.ts
@@ -35,9 +35,9 @@ export class CookieValidator {
     }
 
     return (
-      this.isValidHttpOnly(httpOnly) &&
-      this.isValidSecure(secure) &&
-      this.isValidExpiry(expiry)
+      this.isValidHttpOnly(httpOnly as boolean) &&
+      this.isValidSecure(secure as boolean) &&
+      this.isValidExpiry(expiry as number)
     );
   }
 }

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -90,7 +90,7 @@ class Session {
         await this.browser.close();
         break;
       case COMMANDS.NAVIGATE_TO:
-        await this.navigateTo(parameters.url as string);
+        await this.navigateTo(parameters.url);
         break;
       case COMMANDS.GET_CURRENT_URL:
         response = this.browser.getUrl();
@@ -116,13 +116,12 @@ class Session {
         break;
       case COMMANDS.GET_ELEMENT_TEXT:
         response = this.browser
-          .getKnownElement(urlVariables.elementId as string)
+          .getKnownElement(urlVariables.elementId)
           .getText();
         break;
       case COMMANDS.FIND_ELEMENTS_FROM_ELEMENT:
         response = this.elementRetrieval(
-          this.browser.getKnownElement(urlVariables.elementId as string)
-            .element,
+          this.browser.getKnownElement(urlVariables.elementId).element,
           parameters.using,
           parameters.value,
         );
@@ -130,8 +129,7 @@ class Session {
         break;
       case COMMANDS.FIND_ELEMENT_FROM_ELEMENT:
         response = this.elementRetrieval(
-          this.browser.getKnownElement(urlVariables.elementId as string)
-            .element,
+          this.browser.getKnownElement(urlVariables.elementId).element,
           parameters.using,
           parameters.value,
         )[0];
@@ -166,12 +164,12 @@ class Session {
         break;
       case COMMANDS.GET_ELEMENT_TAG_NAME:
         response = this.browser
-          .getKnownElement(urlVariables.elementId as string)
+          .getKnownElement(urlVariables.elementId)
           .getTagName();
         break;
       case COMMANDS.GET_ELEMENT_ATTRIBUTE:
         response = this.browser
-          .getKnownElement(urlVariables.elementId as string)
+          .getKnownElement(urlVariables.elementId)
           .getElementAttribute(urlVariables.attributeName as string);
         break;
       case COMMANDS.EXECUTE_SCRIPT:
@@ -190,25 +188,25 @@ class Session {
         break;
       case COMMANDS.ELEMENT_CLICK:
         if (!this.browser.dom.window) throw new NoSuchWindow();
-        this.browser.getKnownElement(urlVariables.elementId as string).click();
+        this.browser.getKnownElement(urlVariables.elementId).click();
         response = { value: null };
         break;
       case COMMANDS.ELEMENT_CLEAR:
         if (!this.browser.dom.window) throw new NoSuchWindow();
-        this.browser.getKnownElement(urlVariables.elementId as string).clear();
+        this.browser.getKnownElement(urlVariables.elementId).clear();
         response = { value: null };
         break;
       case COMMANDS.ELEMENT_ENABLED:
         if (!this.browser.dom.window) throw new NoSuchWindow();
         const isEnabled = this.browser
-          .getKnownElement(urlVariables.elementId as string)
+          .getKnownElement(urlVariables.elementId)
           .isEnabled();
         response = { value: isEnabled };
         break;
       case COMMANDS.ELEMENT_IS_DISPLAYED:
         if (!this.browser.dom.window) throw new NoSuchWindow();
         const { element }: WebElement = this.browser.getKnownElement(
-          urlVariables.elementId as string,
+          urlVariables.elementId,
         );
         response = { value: WebElement.isDisplayed(element) };
         break;
@@ -233,7 +231,7 @@ class Session {
       case COMMANDS.ELEMENT_SELECTED:
         if (!this.browser.dom.window) throw new NoSuchWindow();
         const isSelected = this.browser
-          .getKnownElement(urlVariables.elementId as string)
+          .getKnownElement(urlVariables.elementId)
           .isSelected();
         response = { value: isSelected };
         break;
@@ -314,7 +312,7 @@ class Session {
    * navigates to a specified url
    * sets timers according to session config
    */
-  async navigateTo(url: string): Promise<void> {
+  async navigateTo(url?: string): Promise<void> {
     let pathType: string;
 
     try {
@@ -701,7 +699,7 @@ class Session {
         return arg;
       } else {
         const { element } = this.browser.getKnownElement(
-          (arg as string)[ELEMENT],
+          (arg as Record<string, string>)[ELEMENT],
         );
         return element;
       }

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -9,6 +9,7 @@ import {
 // TODO: probably update eslint to avoid the disabled rule below
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Session } from '../Session/Session';
+import { WebElement } from '../WebElement/WebElement';
 
 /**
  * contains interfaces particular to plumadriver
@@ -19,6 +20,24 @@ export namespace Pluma {
   type UserPrompt = (message?: string) => boolean;
   type ElementBooleanAttribute = typeof ElementBooleanAttributeValues.type;
   type PageLoadStrategy = typeof PageLoadStrategyValues.type;
+
+  /**
+   * All the possible return types for a response
+   */
+  type Response =
+    | string
+    | NodeList
+    | Node
+    | NodeList
+    | HTMLCollection
+    | WebElement[]
+    | null
+    | void
+    | Pluma.Cookie[]
+    | {
+        value: boolean | null | Pluma.Cookie | unknown;
+      }
+    | Pluma.SerializedWebElement;
 
   /**
    * Client defined options for jsdom

--- a/src/WebElement/WebElement.ts
+++ b/src/WebElement/WebElement.ts
@@ -35,7 +35,7 @@ class WebElement {
    * returns the textContent of the WebElement's HTML element
    * @returns {String}
    */
-  getText(): string {
+  getText(): string | null {
     return this.element.textContent;
   }
 
@@ -53,7 +53,7 @@ class WebElement {
    * @param name the name of the element attribute
    * @returns {String | null}
    */
-  getElementAttribute(name: string): string {
+  getElementAttribute(name: string): string | null {
     if (ElementBooleanAttributeValues.guard(name))
       return this.element.hasAttribute(name).toString(); // returns 'true' (string) or null
     return this.element.getAttribute(name);
@@ -63,7 +63,7 @@ class WebElement {
    * returns the type attribute of the WebElement's HTML element
    * @returns {String}
    */
-  getType(): string {
+  getType(): string | null {
     return this.element.getAttribute('type');
   }
 
@@ -79,7 +79,7 @@ class WebElement {
       !nextParent || nextParent.tagName.toLowerCase() === tagName.toLowerCase();
 
     while (!isMatchingOrFalsy()) {
-      const { parentElement } = nextParent;
+      const { parentElement } = nextParent as HTMLElement;
       nextParent = parentElement;
     }
 
@@ -97,8 +97,8 @@ class WebElement {
       tagName.toLowerCase() === 'optgroup';
 
     if (isOptionOrOptgroupElement(element)) {
-      const datalistParent: HTMLElement = this.findAncestor('datalist');
-      const selectParent: HTMLElement = this.findAncestor('select');
+      const datalistParent: HTMLElement | null = this.findAncestor('datalist');
+      const selectParent: HTMLElement | null = this.findAncestor('select');
       return datalistParent || selectParent || element;
     }
 
@@ -214,7 +214,7 @@ class WebElement {
     let isEmpty: boolean;
 
     if (isInputElement(element) && has(element, 'files')) {
-      isEmpty = element.files.length === 0;
+      isEmpty = (element.files as FileList).length === 0;
     } else {
       isEmpty = element.value === '';
     }
@@ -268,7 +268,7 @@ class WebElement {
       return false;
     }
 
-    const fieldsetAncestorFirstLegendChild: HTMLLegendElement = fieldsetAncestor.querySelector(
+    const fieldsetAncestorFirstLegendChild: HTMLLegendElement | null = fieldsetAncestor.querySelector(
       'legend',
     );
 
@@ -292,7 +292,7 @@ class WebElement {
       ownerDocument: { doctype },
     } = this.element;
 
-    if (doctype.name === 'xml') {
+    if ((doctype as DocumentType).name === 'xml') {
       return false;
     }
 
@@ -328,9 +328,9 @@ class WebElement {
 
     if (
       (localName === 'option' || localName === 'optgroup') &&
-      element.parentElement.localName === 'select'
+      (element.parentElement as HTMLElement).localName === 'select'
     ) {
-      return WebElement.isDisplayed(parentElement, true);
+      return WebElement.isDisplayed(parentElement as HTMLElement, true);
     }
 
     if (isInputElement(element) && element.type === 'hidden') {
@@ -339,7 +339,7 @@ class WebElement {
 
     if (localName === 'map') {
       const { name, ownerDocument } = element as HTMLMapElement;
-      const imageUsingMap: HTMLElement = ownerDocument.querySelector(
+      const imageUsingMap: HTMLElement | null = ownerDocument.querySelector(
         `img[usemap='#${name}']`,
       );
 
@@ -364,7 +364,7 @@ class WebElement {
       return false;
     }
 
-    if (!WebElement.isDisplayed(parentElement)) {
+    if (!WebElement.isDisplayed(parentElement as HTMLElement)) {
       return false;
     }
 

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { COMMANDS } from '../constants/constants';
+import { Pluma } from '../Types/types';
 import * as utils from '../utils/utils';
 const {
   defaultSessionEndpointLogic,
@@ -33,7 +34,8 @@ cookies.delete(
 );
 
 cookies.use('/:name', (req, res, next) => {
-  req.sessionRequest.urlVariables.cookieName = req.params.name;
+  (req.sessionRequest as Pluma.Request).urlVariables.cookieName =
+    req.params.name;
   next();
 });
 

--- a/src/routes/elements.ts
+++ b/src/routes/elements.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { COMMANDS } from '../constants/constants';
+import { Pluma } from '../Types/types';
 import * as utils from '../utils/utils';
 
 const element = express.Router();
@@ -48,7 +49,8 @@ element.post(
 // get element attribute name
 // this endpoint has not been tested as selenium calls execute script instead. Neded to test
 element.get('/attribute/:name', (req, _res, _next) => {
-  req.sessionRequest.urlVariables.attributeName = req.params.name;
+  (req.sessionRequest as Pluma.Request).urlVariables.attributeName =
+    req.params.name;
   return sessionEndpointExceptionHandler(
     defaultSessionEndpointLogic,
     COMMANDS.GET_ELEMENT_ATTRIBUTE,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import timeouts from './timeouts';
 import navigate from './navigate';
 import cookies from './cookies';
 import { Pluma } from '../Types/types';
+import { Session } from '../Session/Session';
 import * as Utils from '../utils/utils';
 
 const {
@@ -50,9 +51,9 @@ router.post('/session', async (req, res, next) => {
 
 router.delete('/session/:sessionId', async (req, res, next) => {
   const sessionManager = req.app.get('sessionManager');
-  const release = await req.session.mutex.acquire();
+  const release = await (req.session as Session).mutex.acquire();
   try {
-    req.sessionRequest.command = COMMANDS.DELETE_SESSION;
+    (req.sessionRequest as Pluma.Request).command = COMMANDS.DELETE_SESSION;
     await sessionManager.deleteSession(req.session, req.sessionRequest);
     res.send(null);
   } catch (error) {
@@ -139,7 +140,8 @@ router.use('/session/:sessionId/cookie', cookies);
 router.use(
   '/session/:sessionId/element/:elementId',
   (req, res, next) => {
-    req.sessionRequest.urlVariables.elementId = req.params.elementId;
+    (req.sessionRequest as Pluma.Request).urlVariables.elementId =
+      req.params.elementId;
     next();
   },
   element,

--- a/src/routes/timeouts.ts
+++ b/src/routes/timeouts.ts
@@ -1,15 +1,16 @@
 import express from 'express';
+import { Session } from '../Session/Session';
 
 const timeouts = express.Router();
 
 timeouts.get('/', (req, res) => {
-  const response = { value: req.session.getTimeouts() };
+  const response = { value: (req.session as Session).getTimeouts() };
   res.json(response);
 });
 
 // set timeouts
 timeouts.post('/', (req, res) => {
-  req.session.setTimeouts(req.body);
+  (req.session as Session).setTimeouts(req.body);
   res.send({ value: null });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "noImplicitThis": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "strictNullChecks": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Solved the `strictNullChecks` subtask in  #32 .

 strictNullChecks @zthaver

Changed function return types and created new types necessary in order to support `strictNullChecks` in order to support typescript **strict mode**.