### PR TITLE
refactor: clean up enabling strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,14 +1767,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/express-winston": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express-winston/-/express-winston-4.0.0.tgz",
-      "integrity": "sha512-CCNvkHIRKIJGgt64naW7XvsXvw4NkVHHa3EDy63uZzruXaFhZb2+AE0HRZx90ph528D1gm+fx9dA1gmZZ2uzLw==",
-      "requires": {
-        "express-winston": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -4644,12 +4636,12 @@
       }
     },
     "express-winston": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/express-winston/-/express-winston-3.4.0.tgz",
-      "integrity": "sha512-CKo4ESwIV4BpNIsGVNiq2GcAwuomL4dVJRIIH/2K/jMpoRI2DakhkVTtaJACzV7n2I1v+knDJkkjZRCymJ7nmA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/express-winston/-/express-winston-4.0.5.tgz",
+      "integrity": "sha512-n9M1imjDYqPQKp6HdHArAucfF5WNYYG4S/FQPdJTmS7sysXALosBgtWyen74WFS67WiqtbBpwNV5iX7Rk01AKw==",
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.19"
       }
     },
     "extend": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "",
   "main": "./build/index.js",
   "dependencies": {
-    "@types/express-winston": "^4.0.0",
     "async-mutex": "^0.1.4",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "express-winston": "^3.4.0",
+    "express-winston": "^4.0.5",
     "has": "^1.0.3",
     "jsdom": "^16.2.1",
     "mime-types": "^2.1.26",

--- a/src/Browser/Browser.ts
+++ b/src/Browser/Browser.ts
@@ -7,7 +7,6 @@ import * as Utils from '../utils/utils';
 import * as PlumaError from '../Error/errors';
 import { CookieValidator } from './CookieValidator';
 import { Cookie } from 'tough-cookie';
-import { isObject } from '../utils/utils';
 
 /**
  * Plumadriver browser with jsdom at its core.
@@ -288,7 +287,7 @@ class Browser {
                 // renames property for selenium functionality
                 const seconds = new Date(cookie[key]).getTime();
                 currentCookie.expiry = seconds;
-              } else currentCookie[key] = cookie[key];
+              } else Utils.copyProperty(currentCookie, cookie, key);
             });
             delete currentCookie.creation;
             return currentCookie;
@@ -383,7 +382,7 @@ class Browser {
       this.currentBrowsingContextWindow = frameWindow;
     } else if (id === null) {
       this.currentBrowsingContextWindow = this.dom.window;
-    } else if (isObject(id) && typeof id[ELEMENT] === 'string') {
+    } else if (Utils.isJsonWebElement(id)) {
       const { element }: WebElement = this.getKnownElement(id[ELEMENT]);
 
       if (this.isStaleElement(element)) {

--- a/src/Browser/BrowserConfig.ts
+++ b/src/Browser/BrowserConfig.ts
@@ -93,8 +93,7 @@ export class BrowserConfig {
         });
         break;
       case 'ignore':
-        this.beforeParse = (window): void =>
-          this.injectAPIs(window as DOMWindow);
+        this.beforeParse = window => this.injectAPIs(window);
         break;
       default:
         break;
@@ -107,19 +106,18 @@ export class BrowserConfig {
   private beforeParseFactory = (func: Pluma.UserPrompt) => {
     return (window: Pluma.DOMWindow): void => {
       ['confirm', 'alert', 'prompt'].forEach(method => {
-        (window as DOMWindow)[method] = func;
+        window[method] = func;
       });
 
-      this.injectAPIs(window as DOMWindow);
+      this.injectAPIs(window);
     };
   };
 
   /**
    * Injects missing APIs into jsdom for better compatibility.
    */
-  private injectAPIs(window: DOMWindow): void {
+  private injectAPIs(window: Pluma.DOMWindow): void {
     window.HTMLElement.prototype.scrollIntoView = (): void => undefined;
-    // @ts-expect-error Window.Performance.timing no longer exists
     window.performance.timing = {
       navigationStart: window.performance.timeOrigin,
     };

--- a/src/CapabilityValidator/CapabilityValidator.ts
+++ b/src/CapabilityValidator/CapabilityValidator.ts
@@ -211,7 +211,7 @@ class CapabilityValidator {
       },
       runScripts: isBoolean,
       resources(resources): boolean {
-        return resources === 'useable';
+        return resources === 'usable';
       },
       rejectPublicSuffixes: isBoolean,
     };

--- a/src/CapabilityValidator/CapabilityValidator.ts
+++ b/src/CapabilityValidator/CapabilityValidator.ts
@@ -33,23 +33,19 @@ class CapabilityValidator {
       case 'browserName':
       case 'browserVersion':
       case 'platformName':
-        this.valid = typeof capability === 'string';
+        this.valid = isString(capability);
         break;
       case 'acceptInsecureCerts':
-        this.valid = typeof capability === 'boolean';
+        this.valid = isBoolean(capability);
         break;
       case 'pageLoadStrategy':
-        this.valid = typeof capability === 'string';
-        this.valid = this.valid
-          ? PageLoadStrategyValues.guard(capability as string)
-          : this.valid;
-
+        this.valid =
+          isString(capability) && PageLoadStrategyValues.guard(capability);
         break;
       case 'unhandledPromptBehavior':
-        this.valid = typeof capability === 'string';
-        this.valid = this.valid
-          ? unhandledPromptBehaviorValues.guard(capability as string)
-          : this.valid;
+        this.valid =
+          isString(capability) &&
+          unhandledPromptBehaviorValues.guard(capability);
         break;
       case 'proxy':
         this.valid =
@@ -145,11 +141,12 @@ class CapabilityValidator {
                   : validProxy;
                 break;
               case 'noProxy':
-                validProxy = value instanceof Array;
-                if (validProxy) {
-                  (value as string[]).forEach((url: string) => {
+                if (Array.isArray(value)) {
+                  value.forEach(url => {
                     if (validProxy) validProxy = validator.isURL(url);
                   });
+                } else {
+                  validProxy = false;
                 }
                 break;
               default:

--- a/src/Session/Session.ts
+++ b/src/Session/Session.ts
@@ -461,9 +461,9 @@ class Session {
     const requiredCapabilities: Partial<Pluma.Capabilities> = {};
     if (utils.isObject(alwaysMatch)) {
       defaultCapabilities.forEach(key => {
-        if (has(capabilities.alwaysMatch, key)) {
+        if (key in alwaysMatch) {
           const validatedCapability = capabilityValidator.validate(
-            capabilities.alwaysMatch[key],
+            alwaysMatch[key],
             key,
           );
           if (validatedCapability) {
@@ -475,12 +475,13 @@ class Session {
       });
     }
 
-    // validate first match capabilities
-    let allMatchedCapabilities: Record<string, unknown>[] | undefined =
-      capabilities.firstMatch;
-    if (allMatchedCapabilities === undefined) {
-      allMatchedCapabilities = [{}];
-    } else if (
+    // validate first match capabilities:
+    const allMatchedCapabilities =
+      typeof capabilities.firstMatch === 'undefined'
+        ? [{}]
+        : capabilities.firstMatch;
+
+    if (
       !Array.isArray(allMatchedCapabilities) ||
       allMatchedCapabilities.length === 0
     ) {

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -1,4 +1,4 @@
-import { BaseOptions, DOMWindow as JSDOMDOMWindow } from 'jsdom';
+import { BaseOptions, DOMWindow, DOMWindow as JSDOMDOMWindow } from 'jsdom';
 import { Store } from 'tough-cookie';
 import {
   ElementBooleanAttributeValues,
@@ -131,7 +131,7 @@ export namespace Pluma {
   }
 
   interface PlumaOptions {
-    runScripts: BaseOptions['runScripts'];
+    runScripts?: BaseOptions['runScripts'];
     unhandledPromptBehavior?: unhandledPromptBehavior;
     rejectPublicSuffixes?: boolean;
     strictSSL?: boolean;
@@ -190,6 +190,15 @@ declare global {
 
   interface MouseEventInit {
     which?: number;
+  }
+
+  interface Window {
+    [k: string]: unknown;
+    eval: typeof eval;
+    HTMLElement: typeof HTMLElement;
+    SVGElement: typeof SVGElement;
+    NodeList: typeof NodeList;
+    HTMLCollection: typeof HTMLCollection;
   }
 }
 

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -1,4 +1,4 @@
-import { BaseOptions, DOMWindow, DOMWindow as JSDOMDOMWindow } from 'jsdom';
+import { BaseOptions, DOMWindow as JSDOMDOMWindow } from 'jsdom';
 import { Store } from 'tough-cookie';
 import {
   ElementBooleanAttributeValues,

--- a/src/Types/types.d.ts
+++ b/src/Types/types.d.ts
@@ -53,7 +53,6 @@ export namespace Pluma {
    * Expected cookie shape
    */
   interface Cookie {
-    [key: string]: any;
     name: string;
     value: string;
     domain?: string;

--- a/src/Types/untyped-modules.ts
+++ b/src/Types/untyped-modules.ts
@@ -1,0 +1,8 @@
+declare module 'jsdom/lib/jsdom/living/helpers/focusing' {
+  function isFocusableAreaElement(elImpl: unknown): boolean;
+}
+
+declare module 'jsdom/lib/jsdom/living/generated/utils' {
+  // jsdom symbol on HTMLElement for private use
+  const implSymbol: keyof HTMLElement;
+}

--- a/src/WebElement/WebElement.ts
+++ b/src/WebElement/WebElement.ts
@@ -1,7 +1,4 @@
-/* eslint-disable */
-// @ts-nocheck
-//TODO: Install libraries and fix errors for line 3,6 and 7
-import uuidv1 from 'uuid/v1';
+import { v1 as uuidv1 } from 'uuid';
 import has from 'has';
 import { isFocusableAreaElement } from 'jsdom/lib/jsdom/living/helpers/focusing';
 import { implSymbol } from 'jsdom/lib/jsdom/living/generated/utils';

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { Pluma } from './Types/types';
 
 import { SessionManager } from './SessionManager/SessionManager';
 import router from './routes/index';
+import { WebDriverError } from './Error/WebDriverError';
 
 const app = express();
 const sessionManager = new SessionManager();
@@ -30,22 +31,15 @@ app.use(errorLogger);
 
 // error handler
 app.use(
-  (
-    err: Record<string, unknown>,
-    _req: Request,
-    res: Response,
-    _next: NextFunction,
-  ) => {
+  (err: WebDriverError, _req: Request, res: Response, _next: NextFunction) => {
     const errorResponse: Pluma.ErrorResponse = {
       value: {
-        error: err.JSONCodeError as string,
-        message: err.message as string,
-        stacktrace: err.stack as string,
+        error: err.JSONCodeError,
+        message: err.message,
+        stacktrace: err.stack || '',
       },
     };
-    res
-      .status((err.code as number) || (err.status as number) || 500)
-      .json(errorResponse);
+    res.status(err.code || 500).json(errorResponse);
   },
 );
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,4 +1,4 @@
-import { StringUnion } from '../utils/utils';
+import { StringUnion } from '../utils/StringUnion';
 
 /** Boolean attributes [WHATWG](https://html.spec.whatwg.org/#boolean-attribute) */
 export const ElementBooleanAttributeValues = StringUnion(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,3 @@
-/* eslint-disable */
-// @ts-nocheck
-//TODO: Install library and fix error on line 5
 import winston from 'winston';
 import expressWinston from 'express-winston';
 

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import { COMMANDS } from '../constants/constants';
-import { Pluma } from '../Types/types';
 import * as utils from '../utils/utils';
 const {
   defaultSessionEndpointLogic,
@@ -34,8 +33,9 @@ cookies.delete(
 );
 
 cookies.use('/:name', (req, res, next) => {
-  (req.sessionRequest as Pluma.Request).urlVariables.cookieName =
-    req.params.name;
+  if (req.sessionRequest) {
+    req.sessionRequest.urlVariables.cookieName = req.params.name;
+  }
   next();
 });
 

--- a/src/routes/elements.ts
+++ b/src/routes/elements.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import { COMMANDS } from '../constants/constants';
-import { Pluma } from '../Types/types';
 import * as utils from '../utils/utils';
 
 const element = express.Router();
@@ -49,8 +48,9 @@ element.post(
 // get element attribute name
 // this endpoint has not been tested as selenium calls execute script instead. Neded to test
 element.get('/attribute/:name', (req, _res, _next) => {
-  (req.sessionRequest as Pluma.Request).urlVariables.attributeName =
-    req.params.name;
+  if (req.sessionRequest) {
+    req.sessionRequest.urlVariables.attributeName = req.params.name;
+  }
   return sessionEndpointExceptionHandler(
     defaultSessionEndpointLogic,
     COMMANDS.GET_ELEMENT_ATTRIBUTE,

--- a/src/routes/timeouts.ts
+++ b/src/routes/timeouts.ts
@@ -1,16 +1,15 @@
 import express from 'express';
-import { Session } from '../Session/Session';
 
 const timeouts = express.Router();
 
 timeouts.get('/', (req, res) => {
-  const response = { value: (req.session as Session).getTimeouts() };
+  const response = { value: req.session?.getTimeouts() };
   res.json(response);
 });
 
 // set timeouts
 timeouts.post('/', (req, res) => {
-  (req.session as Session).setTimeouts(req.body);
+  req.session?.setTimeouts(req.body);
   res.send({ value: null });
 });
 

--- a/src/utils/StringUnion.ts
+++ b/src/utils/StringUnion.ts
@@ -1,0 +1,35 @@
+// credit where it's due: https://stackoverflow.com/questions/36836011/checking-validity-of-string-literal-union-type-at-runtime/43621735
+export const StringUnion = <UnionType extends string>(
+  ...values: UnionType[]
+): {
+  guard: (value: string) => value is UnionType;
+  check: (value: string) => UnionType;
+  values: UnionType[];
+} & {
+  type: UnionType;
+} => {
+  Object.freeze(values);
+  const valueSet: Set<string> = new Set(values);
+
+  const guard = (value: string): value is UnionType => {
+    return valueSet.has(value);
+  };
+
+  const check = (value: string): UnionType => {
+    if (!guard(value)) {
+      const actual = JSON.stringify(value);
+      const expected = values.map(s => JSON.stringify(s)).join(' | ');
+      throw new TypeError(
+        `Value '${actual}' is not assignable to type '${expected}'.`,
+      );
+    }
+    return value;
+  };
+
+  const unionNamespace = { guard, check, values };
+  return Object.freeze(
+    unionNamespace as typeof unionNamespace & {
+      type: UnionType;
+    },
+  );
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,42 +6,7 @@ import has from 'has';
 import isDisplayedAtom from './isdisplayed-atom.json';
 import { version } from 'pjson';
 import { Session } from '../Session/Session';
-
-// credit where it's due: https://stackoverflow.com/questions/36836011/checking-validity-of-string-literal-union-type-at-runtime/43621735
-export const StringUnion = <UnionType extends string>(
-  ...values: UnionType[]
-): {
-  guard: (value: string) => value is UnionType;
-  check: (value: string) => UnionType;
-  values: UnionType[];
-} & {
-  type: UnionType;
-} => {
-  Object.freeze(values);
-  const valueSet: Set<string> = new Set(values);
-
-  const guard = (value: string): value is UnionType => {
-    return valueSet.has(value);
-  };
-
-  const check = (value: string): UnionType => {
-    if (!guard(value)) {
-      const actual = JSON.stringify(value);
-      const expected = values.map(s => JSON.stringify(s)).join(' | ');
-      throw new TypeError(
-        `Value '${actual}' is not assignable to type '${expected}'.`,
-      );
-    }
-    return value;
-  };
-
-  const unionNamespace = { guard, check, values };
-  return Object.freeze(
-    unionNamespace as typeof unionNamespace & {
-      type: UnionType;
-    },
-  );
-};
+import { ELEMENT } from '../constants/constants';
 
 export const isBrowserOptions = (
   obj: Pluma.BrowserOptions,
@@ -97,7 +62,7 @@ export const fileSystem = {
 
 export const endpoint = {
   sessionEndpointExceptionHandler: (
-    endpointLogic: any,
+    endpointLogic: (req: Request, res: Response) => Promise<unknown>,
     plumaCommand: string,
   ) => async (
     req: Request,
@@ -211,9 +176,12 @@ export const isString = (candidateValue: unknown): candidateValue is string =>
 export const isBoolean = (candidateValue: unknown): candidateValue is boolean =>
   typeof candidateValue === 'boolean';
 
+export const isNumber = (candidateValue: unknown): candidateValue is number =>
+  typeof candidateValue === 'number';
+
 export const isObject = (
   candidateValue: unknown,
-): candidateValue is Record<string, any> => {
+): candidateValue is Record<string, unknown> => {
   return typeof candidateValue === 'object' && candidateValue !== null;
 };
 // Expose the version in package.json
@@ -230,6 +198,11 @@ export const isFrameElement = (
 ): element is HTMLFrameElement => {
   return element.localName === 'frame';
 };
+
+export const isJsonWebElement = (
+  value: unknown,
+): value is { [ELEMENT]: string } =>
+  isObject(value) && isString(value[ELEMENT]);
 
 /** Work-around function for https://github.com/microsoft/TypeScript/issues/31445#issuecomment-576929044 */
 export const copyProperty = <T>(target: T, src: T, prop: keyof T): void => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -69,15 +69,15 @@ export const endpoint = {
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    req.sessionRequest!.command = plumaCommand;
-    const release = await req.session!.mutex.acquire();
+    if (req.sessionRequest) req.sessionRequest.command = plumaCommand;
+    const release = await req.session?.mutex.acquire();
     endpointLogic(req, res)
       .catch((e: Pluma.Request) => {
         e.command = req.sessionRequest?.command || ' ';
         next(e);
       })
       .finally(() => {
-        release();
+        release?.();
       });
   },
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,7 +5,6 @@ import fs from 'fs';
 import has from 'has';
 import isDisplayedAtom from './isdisplayed-atom.json';
 import { version } from 'pjson';
-import { Session } from '../Session/Session';
 import { ELEMENT } from '../constants/constants';
 
 export const isBrowserOptions = (
@@ -23,7 +22,7 @@ export const isBrowserOptions = (
 
 export const validate = {
   requestBodyType(incomingMessage: Request, type: string): boolean {
-    if ((incomingMessage.headers['content-type'] as string).includes(type)) {
+    if (incomingMessage.headers['content-type']?.includes(type)) {
       return true;
     }
     return false;
@@ -50,7 +49,7 @@ export const validate = {
 };
 
 export const fileSystem = {
-  pathExists(path: fs.PathLike): Promise<boolean> {
+  pathExists(path = ''): Promise<boolean> {
     return new Promise((res, rej) => {
       fs.access(path, fs.constants.F_OK, err => {
         if (err) rej(new PlumaError.InvalidArgument());
@@ -85,9 +84,8 @@ export const endpoint = {
     req: Request,
     res: Response,
   ): Promise<void> {
-    const result = await (req.session as Session).process(
-      req.sessionRequest as Pluma.Request,
-    );
+    const result =
+      req.sessionRequest && (await req.session?.process(req.sessionRequest));
     if (result != null) {
       res.json(has(result, 'value') ? result : { value: result });
     }
@@ -134,7 +132,9 @@ export const isEditableFormControlElement = (
   return !element.hidden && !element.readOnly && !element.disabled;
 };
 
-export const isMutableFormControlElement = (element: HTMLElement): boolean => {
+export const isMutableFormControlElement = (
+  element: HTMLElement,
+): element is HTMLInputElement | HTMLTextAreaElement => {
   let isMutable: boolean;
 
   if (isTextAreaElement(element)) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -230,3 +230,8 @@ export const isFrameElement = (
 ): element is HTMLFrameElement => {
   return element.localName === 'frame';
 };
+
+/** Work-around function for https://github.com/microsoft/TypeScript/issues/31445#issuecomment-576929044 */
+export const copyProperty = <T>(target: T, src: T, prop: keyof T): void => {
+  target[prop] = src[prop];
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,13 +12,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "noImplicitThis": true,
-    "strictBindCallApply": true,
-    "strictFunctionTypes": true,
-    "alwaysStrict": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
-    "noImplicitAny": true
+    "strict": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
What this PR does:

- Enable strict mode on temporarily disabled files in #202 
- Fix eslint warning (`explicit any` and `non-null assertion`)
- Remove most explicit casting
- Combine strict options into single `strict: true` to make sure the tests pass
- Fix some minor mistakes

close #32, close #199 